### PR TITLE
공동체 정보 및 설정 보기 페이지

### DIFF
--- a/src/components/common/CommunityInfoCard.tsx
+++ b/src/components/common/CommunityInfoCard.tsx
@@ -1,0 +1,88 @@
+import styled from 'styled-components';
+
+interface CommunityInfoCardProps {
+  name: string;
+  memberInfo: string;
+  creationDate: string;
+  description: string;
+  imageUrl: string;
+}
+
+const CommunityInfoCard = ({
+  name,
+  memberInfo,
+  creationDate,
+  description,
+  imageUrl,
+}: CommunityInfoCardProps) => {
+  return (
+    <CardContainer>
+      <ImageWrapper>
+        <img src={imageUrl} alt={`${name} profile`} />
+      </ImageWrapper>
+      <ContentWrapper>
+        <Name>{name}</Name>
+        <MemberInfo>{memberInfo}</MemberInfo>
+        <Caption>{creationDate}</Caption>
+        <Caption>{description}</Caption>
+      </ContentWrapper>
+    </CardContainer>
+  );
+};
+
+export default CommunityInfoCard;
+
+const CardContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  width: 100%;
+  border-radius: 1.25rem;
+  background-color: ${({ theme }) => theme.colors.white};
+  padding: 2.19rem 1.88rem;
+`;
+
+const ImageWrapper = styled.div`
+  width: 9.375rem;
+  height: 9.375rem;
+  padding: 0.875rem 0.625rem;
+  justify-content: space-between;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 0.625rem;
+  background-color: ${({ theme }) => theme.colors.black200};
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    font-family: ${({ theme }) => theme.fonts.caption};
+    color: ${({ theme }) => theme.colors.black300};
+  }
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.62rem;
+  width: 100%;
+`;
+
+const Name = styled.span`
+  font-family: ${({ theme }) => theme.fonts.nickname};
+  color: ${({ theme }) => theme.colors.black100};
+`;
+
+const MemberInfo = styled.span`
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.blue100};
+`;
+
+const Caption = styled.span`
+  font-family: ${({ theme }) => theme.fonts.caption};
+  color: ${({ theme }) => theme.colors.black200};
+`;

--- a/src/components/communityinfosetting/CommunityInfoSection.tsx
+++ b/src/components/communityinfosetting/CommunityInfoSection.tsx
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import TitleAndFieldContainer from '@src/components/common/TitleAndFieldContainer';
+import CommunityInfoCard from '@src/components/common/CommunityInfoCard';
 
 interface CommunityInfoProps {
   name: string;
@@ -19,74 +19,15 @@ const CommunityInfoSection = ({
   const subtitle = '공동체 정보';
   return (
     <TitleAndFieldContainer title={subtitle}>
-      <CardContainer>
-        <ImageWrapper>
-          <img src={imageUrl} alt={`${name} profile`} />
-        </ImageWrapper>
-        <ContentWrapper>
-          <Name>{name}</Name>
-          <MemberInfo>{memberInfo}</MemberInfo>
-          <Caption>{creationDate}</Caption>
-          <Caption>{description}</Caption>
-        </ContentWrapper>
-      </CardContainer>
+      <CommunityInfoCard
+        name={name}
+        memberInfo={memberInfo}
+        creationDate={creationDate}
+        description={description}
+        imageUrl={imageUrl}
+      />
     </TitleAndFieldContainer>
   );
 };
 
 export default CommunityInfoSection;
-
-const CardContainer = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1.25rem;
-  width: 100%;
-  border-radius: 1.25rem;
-  background-color: ${({ theme }) => theme.colors.white};
-  padding: 2.19rem 1.88rem;
-`;
-
-const ImageWrapper = styled.div`
-  width: 9.375rem;
-  height: 9.375rem;
-  padding: 0.875rem 0.625rem;
-  justify-content: space-between;
-  align-items: center;
-  overflow: hidden;
-  border-radius: 0.625rem;
-  background-color: ${({ theme }) => theme.colors.black200};
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    font-family: ${({ theme }) => theme.fonts.caption};
-    color: ${({ theme }) => theme.colors.black300};
-  }
-`;
-
-const ContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.62rem;
-  width: 100%;
-`;
-
-const Name = styled.span`
-  font-family: ${({ theme }) => theme.fonts.nickname};
-  color: ${({ theme }) => theme.colors.black100};
-`;
-
-const MemberInfo = styled.span`
-  font-family: ${({ theme }) => theme.fonts.body};
-  color: ${({ theme }) => theme.colors.blue100};
-`;
-
-const Caption = styled.span`
-  font-family: ${({ theme }) => theme.fonts.caption};
-  color: ${({ theme }) => theme.colors.black200};
-`;

--- a/src/components/communityinfosetting/CommunityInfoSection.tsx
+++ b/src/components/communityinfosetting/CommunityInfoSection.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import styled from 'styled-components';
-import SectionContainer from '@src/components/communityinfosetting/SectionContainer';
+import TitleAndFieldContainer from '@src/components/common/TitleAndFieldContainer';
 
 interface CommunityInfoProps {
   name: string;
@@ -10,17 +9,16 @@ interface CommunityInfoProps {
   imageUrl: string;
 }
 
-const CommunityInfoSection: React.FC<CommunityInfoProps> = ({
+const CommunityInfoSection = ({
   name,
   memberInfo,
   creationDate,
   description,
   imageUrl,
-}) => {
+}: CommunityInfoProps) => {
   const subtitle = '공동체 정보';
   return (
-    <SectionContainer>
-      <Body>{subtitle}</Body>
+    <TitleAndFieldContainer title={subtitle}>
       <CardContainer>
         <ImageWrapper>
           <img src={imageUrl} alt={`${name} profile`} />
@@ -32,16 +30,11 @@ const CommunityInfoSection: React.FC<CommunityInfoProps> = ({
           <Caption>{description}</Caption>
         </ContentWrapper>
       </CardContainer>
-    </SectionContainer>
+    </TitleAndFieldContainer>
   );
 };
 
 export default CommunityInfoSection;
-
-const Body = styled.h2`
-  font-family: ${({ theme }) => theme.fonts.body};
-  color: ${({ theme }) => theme.colors.black100};
-`;
 
 const CardContainer = styled.section`
   display: flex;

--- a/src/components/communityinfosetting/CommunityInfoSection.tsx
+++ b/src/components/communityinfosetting/CommunityInfoSection.tsx
@@ -28,8 +28,8 @@ const CommunityInfoSection: React.FC<CommunityInfoProps> = ({
         <ContentWrapper>
           <Name>{name}</Name>
           <MemberInfo>{memberInfo}</MemberInfo>
-          <CreationDate>{creationDate}</CreationDate>
-          <Description>{description}</Description>
+          <Caption>{creationDate}</Caption>
+          <Caption>{description}</Caption>
         </ContentWrapper>
       </CardContainer>
     </SectionContainer>
@@ -83,22 +83,17 @@ const ContentWrapper = styled.div`
   width: 100%;
 `;
 
-const Name = styled.div`
+const Name = styled.span`
   font-family: ${({ theme }) => theme.fonts.nickname};
   color: ${({ theme }) => theme.colors.black100};
 `;
 
-const MemberInfo = styled.div`
+const MemberInfo = styled.span`
   font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.blue100};
 `;
 
-const CreationDate = styled.div`
-  font-family: ${({ theme }) => theme.fonts.caption};
-  color: ${({ theme }) => theme.colors.black200};
-`;
-
-const Description = styled.div`
+const Caption = styled.span`
   font-family: ${({ theme }) => theme.fonts.caption};
   color: ${({ theme }) => theme.colors.black200};
 `;

--- a/src/components/communityinfosetting/CommunitySettingSection.tsx
+++ b/src/components/communityinfosetting/CommunitySettingSection.tsx
@@ -1,20 +1,17 @@
-import React from 'react';
-import SectionContainer from '@src/components/communityinfosetting/SectionContainer';
-import styled from 'styled-components';
 import CommunityButton from '@src/components/common/CommunityButton';
 import { CommunityRoleType } from '@src/pages/communityinfosetting/CommunityInfoSettingPage';
+import TitleAndFieldContainer from '@src/components/common/TitleAndFieldContainer';
 
 export interface CommunitySettingSectionProps {
   communityRole: CommunityRoleType;
 }
 
-const CommunitySettingSection: React.FC<CommunitySettingSectionProps> = ({
+const CommunitySettingSection = ({
   communityRole,
-}) => {
+}: CommunitySettingSectionProps) => {
   const subtitle = '공동체 설정';
   return (
-    <SectionContainer>
-      <Body>{subtitle}</Body>
+    <TitleAndFieldContainer title={subtitle}>
       {communityRole === 'admin' && (
         <>
           <CommunityButton
@@ -36,13 +33,8 @@ const CommunitySettingSection: React.FC<CommunitySettingSectionProps> = ({
           onClick={() => alert('leaveCommunity')}
         />
       )}
-    </SectionContainer>
+    </TitleAndFieldContainer>
   );
 };
 
 export default CommunitySettingSection;
-
-const Body = styled.h2`
-  font-family: ${({ theme }) => theme.fonts.body};
-  color: ${({ theme }) => theme.colors.black100};
-`;


### PR DESCRIPTION
## 🔎 What is this PR?

Resolves #26, Resolves #38 

### Product spec
- 공동체 정보 보기
- 공동체 권한에 따른 공동체 설정 보기 (admin/user)

### Tech spec
별도의 라이브러리 설치 X


### 디자인 (Figma)
admin/user
<img width="373" alt="image" src="https://github.com/user-attachments/assets/88e4e692-b504-4315-8225-81c6b203bd3c">





## ✨ 설명
위의 사진과 같은 공동체 정보&설정 페이지 퍼블리싱입니다.
디자인 가이드에서 확정되지 않은 설정 버튼 클릭 후의 플로우는 _구현되지 않았습니다._

### 공동체 버튼 컴포넌트
`common > CommunityButton.tsx`

공동체 사이드바에서 사용하는 버튼과 설정 버튼의 레이아웃이 동일하여 공통 UI 컴포넌트로 제작했습니다. 
PR을 따로 보낼까 하다가 전부 제가 작업하는 컴포넌트라서 이 PR에 포함합니다.

flex를 이용한 단순한 UI 컴포넌트입니다. 총 5가지 종류의 버튼이 존재해, 타입으로 정의하여 사용했습니다.
buttonConfig를 만들어 props에서 건네는 타입에 따라 컴포넌트에 필요한 value (name, icon)을 불러옵니다. 

사이드바에서 사용하는 화면은 다음 사진과 같습니다.
<img width="287" alt="image" src="https://github.com/user-attachments/assets/4ad530d5-29ab-48e4-ad72-965d526ce4d7">

### 섹션 컨테이너 컴포넌트 
`communityinfosetting > SectionContainer.tsx`

공동체 정보와 공동체 설정을 하나의 섹션으로 설정하고, 텍스트와 기타 컴포넌트를 포함하는 flex UI 컴포넌트를 구현했습니다. 
단순히 gap을 이용하여 작업했습니다. (좌우 패딩의 경우 페이지 컨테이너에서 관리합니다.)

### 공동체 인포 섹션 컴포넌트
`communityinfosetting > CommunityInfoSection.tsx`

프로필 디폴트 이미지가 미정인 관계로, `black200` color을 사용해 background-color만 적용해두었습니다.
이미지를 찾지 못하는 경우 발생하는 alt 역시 색상이나 보여지는 방법이 정해지지 않아 기본값을 따릅니다. 혹시 hover 시에만 alt가 보여야하는 디자인으로 변경된다면 새 컴포넌트가 추가될 예정입니다.

`subtitle`( = '공동체정보')을 제외한 컴포넌트에 보여지는 모든 값은 page에서 불러오는 API를 통해 props로 가져옵니다.

### 공동체 설정 섹션 컴포넌트
`communityinfosetting > CommunitySettingSection.tsx`

사용자 권한에 따라 보여지는 버튼이 달라, 조건부 렌더링을 사용했습니다. 

api 명세에서 권한을 확인하는 부분을 찾지 못해 질문 후 role 상태 관리 함수 제작 예정입니다.

### 공동체 정보 및 설정 페이지

`pages > communityinfosetting > CommunityInfoSettingPage.tsx`

Container라는 styled-component를 만들어 페이지 전체 좌우 패딩 및 header와의 패딩 설정을 진행했습니다. 
이 페이지에서 뷰포트 (100svw)를 이용해 width를 지정했고, 이하의 컴포넌트에서는 %를 사용해 100svw 안에서 동작하도록 설정했습니다.
설정하면서 불편했던 점이 있는데, 논의를 통해 구버전 브라우저 비호환 방지를 위해 svw와 vw를 함께 작성하기로 했는데 빌드 및 실행할 때마다 property overwritten 경고가 나타났습니다. ㅠㅠ 혹시 안불편하셨는지요....

페이지에 존재하는 모든 API 데이터는 이 파일에서 불러올 예정입니다. 아직 API 배포 이전이므로 delay 함수를 util에 만들어 비동기처리를 테스트했습니다.

loading 중이거나 error 발생했을 때 나타나는 페이지에 대해서도 아직 디자인 결정 및 논의가 안된 것 같아 일단 임의로 리턴하였습니다. 추후 loading/error를 전역에서 관리한다면 삭제될 코드입니다.



## 📷 스크린샷 (선택)

## ✅ 테스트 체크리스트

### 공동체 버튼 컴포넌트 테스트 코드

- [x] 공동체 권한 넘기기 버튼을 렌더링한다.
- [x] 공동체 삭제하기 버튼을 렌더링한다.
- [x] 공동체 나가기버튼을 렌더링한다.
- [x] 초대 링크 복사하기버튼을 렌더링한다.
- [x] 상세 정보 설정 버튼을 렌더링한다.
- [x] 버튼을 클릭했을 때 onClick 이벤트를 호출한다.

### 공동체 정보 섹션 컴포넌트 테스트 코드
- [x] 공동체 이미지를 렌더링한다.
- [x] 공동체 이름을 렌더링한다.
- [x] 공동체 멤버 정보를 렌더링한다.
- [x] 공동체 생성 날짜를 렌더링한다.
- [x] 공동체 설명을 렌더링한다.

### 공동체 설정 섹션 컴포넌트 테스트 코드
- [x] 관리자 역할일 때 권한 넘기기 & 삭제하기 옵션을 렌더링한다.
- [x] 일반 사용자 역할일 때 나가기 옵션을 렌더링한다.

## 💡 집중 리뷰 요청

평소 혜린님이 코드를 작성할 때 중요하게 생각하는 부분을 집중적으로 체크해주세요!! 특히 모듈화나 코드를 더 단순히 or 쫌쫌하게 짤 수 있는 방법을 알려주시면 다음 코드 작성때 반영하겠습니다. +_+

또한 제 코드에서 코드리뷰 전 이해해주셨으면 하는 부분을 몇 가지 적어보겠습니다!
**타입과 인터페이스 모두 로컬파일에서 정의했습니다.ㅠㅠ** 생각보다 타입 정의 위치, 선언할 타입 개수 등등 고민하는 데에 시간이 길어져서 과감히 지역에서 사용했고, 따라서 export 및 import도 규칙없이 작성했습니다. 화요일 논의 이후에 한 번에 정리하여 코드 개선하겠습니다. 이 부분은 리뷰 패스 부탁드려요!
테스트 코드의 경우 주로 정상작동과 관련된 케이스만 작성했습니다. 잘못된 props가 전달된 경우, 비정상 이벤트가 발생한 경우와 같은 케이스는 테스트 코드 작성에 익숙해지면 차차 추가하겠습니다. 혹시 제안할만한 테케 or 저와 달리 작성하신 좋은 테케가 있다면 코멘트 달아주시면 감사하겠습니다 (--)(__)
