### PR TITLE
BadgeListItem 컴포넌트 (공통)

### DIFF
--- a/src/components/common/BadgeListItem.tsx
+++ b/src/components/common/BadgeListItem.tsx
@@ -1,0 +1,93 @@
+import { theme } from '@src/styles/theme';
+import styled from 'styled-components';
+
+interface ItemProps {
+  imgUrl: string;
+  nickname: string;
+  time: string;
+  text: string;
+  isRead: boolean;
+}
+
+interface BadgeListItemProps {
+  listItem: ItemProps;
+  type: 'notice' | 'chatting';
+}
+
+const BadgeListItem = ({ type, listItem }: BadgeListItemProps) => {
+  const { imgUrl, nickname, time, text, isRead } = listItem;
+
+  const decideCaptionColor = (): string => {
+    if (!isRead) return theme.colors.blue100;
+
+    if (type === 'notice') return theme.colors.black200;
+    return theme.colors.black100;
+  };
+
+  return (
+    <SLayout>
+      <SImg src={imgUrl} />
+      <SContainer>
+        <SWrapper>
+          <SCaption $color={decideCaptionColor}>{nickname}</SCaption>
+          <SCaption $color={decideCaptionColor}>{time}</SCaption>
+        </SWrapper>
+        <SMessage $color={isRead && type === 'chatting'}>{text}</SMessage>
+      </SContainer>
+      {!isRead && <SCircle />}
+    </SLayout>
+  );
+};
+
+export default BadgeListItem;
+
+const SLayout = styled.div`
+  display: flex;
+  gap: 0.125rem;
+
+  padding: 0.9375rem 0.625rem;
+
+  border-radius: 1.25rem;
+  background-color: ${theme.colors.white};
+
+  cursor: pointer;
+`;
+const SImg = styled.img`
+  width: 2.5rem;
+  height: 2.5rem;
+
+  background-color: ${theme.colors.blue300};
+  border-radius: 50%;
+`;
+const SContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  padding: 0 0.5rem;
+  width: calc(100% - 3.125rem);
+`;
+const SWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+const SCaption = styled.span<{ $color: () => string }>`
+  ${theme.fonts.caption};
+  color: ${({ $color }) => $color};
+`;
+const SMessage = styled.span<{ $color: boolean }>`
+  ${theme.fonts.body};
+  color: ${({ $color }) =>
+    $color ? theme.colors.black200 : theme.colors.black100};
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+const SCircle = styled.div`
+  width: 0.375rem;
+  height: 0.375rem;
+
+  border-radius: 50%;
+  background-color: ${theme.colors.blue100};
+`;

--- a/src/components/common/BadgeListItem.tsx
+++ b/src/components/common/BadgeListItem.tsx
@@ -1,4 +1,3 @@
-import { theme } from '@src/styles/theme';
 import styled from 'styled-components';
 
 interface ItemProps {
@@ -17,11 +16,11 @@ interface BadgeListItemProps {
 const BadgeListItem = ({ type, listItem }: BadgeListItemProps) => {
   const { imgUrl, nickname, time, text, isRead } = listItem;
 
-  const decideCaptionColor = (): string => {
-    if (!isRead) return theme.colors.blue100;
+  const decideCaptionColor = (): 'new' | 'notice' | 'chatting' => {
+    if (!isRead) return 'new';
 
-    if (type === 'notice') return theme.colors.black200;
-    return theme.colors.black100;
+    if (type === 'notice') return 'notice';
+    return 'chatting';
   };
 
   return (
@@ -29,8 +28,8 @@ const BadgeListItem = ({ type, listItem }: BadgeListItemProps) => {
       <SImg src={imgUrl} />
       <SContainer>
         <SWrapper>
-          <SCaption $color={decideCaptionColor}>{nickname}</SCaption>
-          <SCaption $color={decideCaptionColor}>{time}</SCaption>
+          <SCaption className={decideCaptionColor()}>{nickname}</SCaption>
+          <SCaption className={decideCaptionColor()}>{time}</SCaption>
         </SWrapper>
         <SMessage $color={isRead && type === 'chatting'}>{text}</SMessage>
       </SContainer>
@@ -48,7 +47,7 @@ const SLayout = styled.div`
   padding: 0.9375rem 0.625rem;
 
   border-radius: 1.25rem;
-  background-color: ${theme.colors.white};
+  background-color: ${({ theme }) => theme.colors.white};
 
   cursor: pointer;
 `;
@@ -56,7 +55,7 @@ const SImg = styled.img`
   width: 2.5rem;
   height: 2.5rem;
 
-  background-color: ${theme.colors.blue300};
+  background-color: ${({ theme }) => theme.colors.blue300};
   border-radius: 50%;
 `;
 const SContainer = styled.div`
@@ -71,13 +70,22 @@ const SWrapper = styled.div`
   display: flex;
   justify-content: space-between;
 `;
-const SCaption = styled.span<{ $color: () => string }>`
-  ${theme.fonts.caption};
-  color: ${({ $color }) => $color};
+const SCaption = styled.span`
+  ${({ theme }) => theme.fonts.caption};
+
+  &.new {
+    color: ${({ theme }) => theme.colors.blue100};
+  }
+  &.notice {
+    color: ${({ theme }) => theme.colors.black200};
+  }
+  &.chatting {
+    color: ${({ theme }) => theme.colors.black100};
+  }
 `;
 const SMessage = styled.span<{ $color: boolean }>`
-  ${theme.fonts.body};
-  color: ${({ $color }) =>
+  ${({ theme }) => theme.fonts.body};
+  color: ${({ theme, $color }) =>
     $color ? theme.colors.black200 : theme.colors.black100};
 
   overflow: hidden;
@@ -89,5 +97,5 @@ const SCircle = styled.div`
   height: 0.375rem;
 
   border-radius: 50%;
-  background-color: ${theme.colors.blue100};
+  background-color: ${({ theme }) => theme.colors.blue100};
 `;


### PR DESCRIPTION
## 🔎 What is this PR?
Resolves #49 

## ✨ 설명
알림 목록 페이지와 채팅 목록 페이지에 사용된 뱃지가 달린 리스트 컴포넌트를 공통 컴포넌트로 작성한다.

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/cef58348-6ffd-4c5a-8d78-f87b60ae395c)


## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
사용하는 게 혜린님이 될 거 같아서 리뷰 요청 드립니다!!

스타일드 컴포넌트에 props 여럿 내려서 삼항 조건문 쓰니까 가독성이 떨어지는 거 같아서 함수로 미리 처리하고 하나의 값으로 내려보내도록 작성했습니다. 이 과정에서 theme을 themeprovider를 이용하지 않고 import문으로 따로 호출해서 썼는데 다른 파일과 통일하지 않아도 괜찮나요??
