### PR TITLE
알림 페이지

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,8 +78,6 @@
     "react/require-default-props": "off",
     // ...props 허용
     "react/jsx-props-no-spreading": "off",
-    // key 값으로 배열의 index를 사용할 수 있게 허용
-    "react/no-array-index-key": "off",
     // styled-components를 뒤에 선언할 수 있게 허용
     "no-use-before-define": "off",
     // 화살표 함수의 중괄호 여부 스타일을 검사하지 않음

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,6 +78,8 @@
     "react/require-default-props": "off",
     // ...props 허용
     "react/jsx-props-no-spreading": "off",
+    // key 값으로 배열의 index를 사용할 수 있게 허용
+    "react/no-array-index-key": "off",
     // styled-components를 뒤에 선언할 수 있게 허용
     "no-use-before-define": "off",
     // 화살표 함수의 중괄호 여부 스타일을 검사하지 않음

--- a/src/components/common/BadgeListItem.tsx
+++ b/src/components/common/BadgeListItem.tsx
@@ -1,37 +1,32 @@
 import styled from 'styled-components';
 
-interface ItemProps {
-  imgUrl: string;
-  nickname: string;
-  time: string;
-  text: string;
-  isRead: boolean;
-}
-
-interface BadgeListItemProps {
-  listItem: ItemProps;
+interface BadgeListItemProps extends BadgeItem {
   type: 'notice' | 'chatting';
 }
 
-const BadgeListItem = ({ type, listItem }: BadgeListItemProps) => {
-  const { imgUrl, nickname, time, text, isRead } = listItem;
-
-  const decideCaptionColor = (): 'new' | 'notice' | 'chatting' => {
-    if (!isRead) return 'new';
-
-    if (type === 'notice') return 'notice';
-    return 'chatting';
-  };
-
+const BadgeListItem = ({
+  type,
+  imgUrl,
+  caption,
+  time,
+  message,
+  isRead,
+}: BadgeListItemProps) => {
   return (
     <SLayout>
       <SImg src={imgUrl} />
       <SContainer>
         <SWrapper>
-          <SCaption className={decideCaptionColor()}>{nickname}</SCaption>
-          <SCaption className={decideCaptionColor()}>{time}</SCaption>
+          <SCaption className={type} $isRead={isRead}>
+            {caption}
+          </SCaption>
+          <SCaption className={type} $isRead={isRead}>
+            {time}
+          </SCaption>
         </SWrapper>
-        <SMessage $color={isRead && type === 'chatting'}>{text}</SMessage>
+        <SMessage className={type} $isRead={isRead}>
+          {message}
+        </SMessage>
       </SContainer>
       {!isRead && <SCircle />}
     </SLayout>
@@ -70,27 +65,32 @@ const SWrapper = styled.div`
   display: flex;
   justify-content: space-between;
 `;
-const SCaption = styled.span`
+const SCaption = styled.span<{ $isRead: boolean }>`
   ${({ theme }) => theme.fonts.caption};
 
-  &.new {
-    color: ${({ theme }) => theme.colors.blue100};
-  }
   &.notice {
-    color: ${({ theme }) => theme.colors.black200};
+    color: ${({ $isRead, theme }) =>
+      $isRead ? theme.colors.black200 : theme.colors.blue100};
   }
   &.chatting {
-    color: ${({ theme }) => theme.colors.black100};
+    color: ${({ $isRead, theme }) =>
+      $isRead ? theme.colors.black100 : theme.colors.blue100};
   }
 `;
-const SMessage = styled.span<{ $color: boolean }>`
+const SMessage = styled.span<{ $isRead: boolean }>`
   ${({ theme }) => theme.fonts.body};
-  color: ${({ theme, $color }) =>
-    $color ? theme.colors.black200 : theme.colors.black100};
 
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  &.notice {
+    color: ${({ theme }) => theme.colors.black100};
+  }
+  &.chatting {
+    color: ${({ $isRead, theme }) =>
+      $isRead ? theme.colors.black200 : theme.colors.black100};
+  }
 `;
 const SCircle = styled.div`
   width: 0.375rem;

--- a/src/components/common/BadgeListItem.tsx
+++ b/src/components/common/BadgeListItem.tsx
@@ -1,12 +1,15 @@
 import styled from 'styled-components';
 
-export interface BadgeListItemProps {
-  type: 'notice' | 'chatting';
+type BadgeListItemType = {
   imgUrl: string;
   caption: string;
   time: string;
   message: string;
   isRead: boolean;
+};
+interface Props extends BadgeListItemType {
+  type: 'notice' | 'chatting';
+  onClick: () => void;
 }
 
 const BadgeListItem = ({
@@ -16,9 +19,10 @@ const BadgeListItem = ({
   time,
   message,
   isRead,
-}: BadgeListItemProps) => {
+  onClick,
+}: Props) => {
   return (
-    <SLayout>
+    <SLayout onClick={onClick}>
       <SImg src={imgUrl} />
       <SContainer>
         <SWrapper>

--- a/src/components/common/BadgeListItem.tsx
+++ b/src/components/common/BadgeListItem.tsx
@@ -1,7 +1,12 @@
 import styled from 'styled-components';
 
-interface BadgeListItemProps extends BadgeItem {
+export interface BadgeListItemProps {
   type: 'notice' | 'chatting';
+  imgUrl: string;
+  caption: string;
+  time: string;
+  message: string;
+  isRead: boolean;
 }
 
 const BadgeListItem = ({

--- a/src/components/common/BadgeListItem.tsx
+++ b/src/components/common/BadgeListItem.tsx
@@ -40,7 +40,7 @@ const BadgeListItem = ({
 
 export default BadgeListItem;
 
-const SLayout = styled.div`
+const SLayout = styled.li`
   display: flex;
   gap: 0.125rem;
 

--- a/src/components/notification/NotiItem.tsx
+++ b/src/components/notification/NotiItem.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { formatTimeGap } from '@src/utils/formatters';
+import BadgeListItem from '@src/components/common/BadgeListItem';
+
+export type NotiItemType = {
+  id: number;
+  createdAt: string;
+  server: string;
+  serverImg: string;
+  content: string;
+  isRead: boolean;
+  link: string;
+};
+
+const NotiItem = ({
+  createdAt,
+  server,
+  serverImg,
+  content,
+  isRead,
+  link,
+}: Omit<NotiItemType, 'id'>) => {
+  const navigate = useNavigate();
+  const [isNotiRead, setIsNotiRead] = useState<boolean>(isRead);
+
+  function handleNavigate() {
+    navigate(link);
+  }
+  function handleClick() {
+    setIsNotiRead(true);
+    // isNotiRead 서버 PATCH
+    handleNavigate();
+  }
+
+  return (
+    <BadgeListItem
+      type='notice'
+      imgUrl={serverImg}
+      caption={server}
+      time={formatTimeGap(new Date(), new Date(createdAt))}
+      message={content}
+      isRead={isNotiRead}
+      onClick={isNotiRead ? handleNavigate : handleClick}
+    />
+  );
+};
+
+export default NotiItem;

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -1,5 +1,98 @@
+import { useEffect, useState } from 'react';
+import { formatTimeGap } from '@src/utils/formatters';
+import styled from 'styled-components';
+import Header from '@src/components/common/Header';
+import BadgeListItem from '@src/components/common/BadgeListItem';
+
+const mock: BadgeItem[] = [
+  {
+    imgUrl: '/',
+    caption: 'AAA공동체 - BBB모임',
+    time: '2024-11-08 02:05:00',
+    message: 'OO님이 나를 언급했어요.',
+    isRead: false,
+  },
+  {
+    imgUrl: '/',
+    caption: 'AAA공동체 - BBB모임',
+    time: '2024-11-08 02:04:30',
+    message: 'OO님이 나를 언급했어요.',
+    isRead: false,
+  },
+  {
+    imgUrl: '/',
+    caption: 'AAA공동체 - BBB모임',
+    time: '2024-11-08 01:50:59',
+    message: 'OO님이 나를 언급했어요.',
+    isRead: false,
+  },
+  {
+    imgUrl: '/',
+    caption: 'AAA공동체 - BBB모임',
+    time: '2024-11-08 01:00:00',
+    message: 'OO님이 나를 언급했어요.',
+    isRead: false,
+  },
+  {
+    imgUrl: '/',
+    caption: 'AAA공동체 - BBB모임',
+    time: '2024-10-21 01:00:00',
+    message: 'OO님이 나를 언급했어요.',
+    isRead: false,
+  },
+  {
+    imgUrl: '/',
+    caption: 'CCC공동체 - DDD모임',
+    time: '2024-09-07 23:00:00',
+    message: '등반 모임 생성이 완료됐어요.',
+    isRead: true,
+  },
+  {
+    imgUrl: '/',
+    caption: 'EEE공동체 - FFF모임',
+    time: '2020-11-07 00:00:00',
+    message: 'OO님이 내 감상평에 반응을 남겼어요.',
+    isRead: true,
+  },
+];
+
 const NotificationPage = () => {
-  return <div />;
+  const [notiList, setNotiList] = useState<BadgeItem[]>([]);
+
+  useEffect(() => {
+    const data = mock; // 데이터 fetch
+    setNotiList(
+      data.map((item) => {
+        const time = formatTimeGap(new Date(), new Date(item.time));
+        return { ...item, time };
+      }),
+    );
+  }, []);
+
+  return (
+    <Layout>
+      <Header text='알림' headerType='hamburger' />
+      <Ul>
+        {notiList.map((item) => (
+          <li key={item.time}>
+            <BadgeListItem type='notice' {...item} />
+          </li>
+        ))}
+      </Ul>
+    </Layout>
+  );
 };
 
 export default NotificationPage;
+
+const Layout = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+`;
+const Ul = styled.ul`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.62rem;
+
+  margin: 0.94rem 5%;
+`;

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 import { formatTimeGap } from '@src/utils/formatters';
 import styled from 'styled-components';
 import Header from '@src/components/common/Header';
-import BadgeListItem from '@src/components/common/BadgeListItem';
+import BadgeListItem, { type BadgeListItemProps } from '@src/components/common/BadgeListItem';
 
-const mock: BadgeItem[] = [
+const mock: Omit<BadgeListItemProps, 'type'>[] = [
   {
     imgUrl: '/',
     caption: 'AAA공동체 - BBB모임',
@@ -57,7 +57,7 @@ const mock: BadgeItem[] = [
 ];
 
 const NotificationPage = () => {
-  const [notiList, setNotiList] = useState<BadgeItem[]>([]);
+  const [notiList, setNotiList] = useState<Omit<BadgeListItemProps, 'type'>[]>([]);
 
   useEffect(() => {
     const data = mock; // 데이터 fetch

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -1,66 +1,43 @@
 import { useEffect, useState } from 'react';
-import { formatTimeGap } from '@src/utils/formatters';
 import styled from 'styled-components';
 import Header from '@src/components/common/Header';
-import BadgeListItem, { type BadgeListItemProps } from '@src/components/common/BadgeListItem';
+import NotiItem, { type NotiItemType } from '@src/components/notification/NotiItem';
 
-const mock: Omit<BadgeListItemProps, 'type'>[] = [
+const mock: NotiItemType[] = [
   {
-    imgUrl: '/',
-    caption: 'AAA공동체 - BBB모임',
-    time: '2024-11-08 02:05:00',
-    message: 'OO님이 나를 언급했어요.',
+    id: 3,
+    createdAt: '2024-10-21 01:00:00',
+    server: 'AAA공동체 - BBB모임',
+    serverImg: '/',
+    content: 'OO님이 나를 언급했어요.',
     isRead: false,
+    link: '/3',
   },
   {
-    imgUrl: '/',
-    caption: 'AAA공동체 - BBB모임',
-    time: '2024-11-08 02:04:30',
-    message: 'OO님이 나를 언급했어요.',
-    isRead: false,
-  },
-  {
-    imgUrl: '/',
-    caption: 'AAA공동체 - BBB모임',
-    time: '2024-11-08 01:50:59',
-    message: 'OO님이 나를 언급했어요.',
-    isRead: false,
-  },
-  {
-    imgUrl: '/',
-    caption: 'AAA공동체 - BBB모임',
-    time: '2024-11-08 01:00:00',
-    message: 'OO님이 나를 언급했어요.',
-    isRead: false,
-  },
-  {
-    imgUrl: '/',
-    caption: 'AAA공동체 - BBB모임',
-    time: '2024-10-21 01:00:00',
-    message: 'OO님이 나를 언급했어요.',
-    isRead: false,
-  },
-  {
-    imgUrl: '/',
-    caption: 'CCC공동체 - DDD모임',
-    time: '2024-09-07 23:00:00',
-    message: '등반 모임 생성이 완료됐어요.',
+    id: 2,
+    createdAt: '2024-09-07 23:00:00',
+    server: 'CCC공동체 - DDD모임',
+    serverImg: '/',
+    content: '등반 모임 생성이 완료됐어요.',
     isRead: true,
+    link: '/2',
   },
   {
-    imgUrl: '/',
-    caption: 'EEE공동체 - FFF모임',
-    time: '2020-11-07 00:00:00',
-    message: 'OO님이 내 감상평에 반응을 남겼어요.',
+    id: 1,
+    createdAt: '2020-11-07 00:00:00',
+    server: 'EEE공동체 - FFF모임',
+    serverImg: '/',
+    content: 'OO님이 내 감상평에 반응을 남겼어요.',
     isRead: true,
+    link: '/1',
   },
 ];
 
 const NotificationPage = () => {
-  const [notiList, setNotiList] = useState<Omit<BadgeListItemProps, 'type'>[]>([]);
+  const [notiList, setNotiList] = useState<NotiItemType[]>([]);
 
   useEffect(() => {
-    const data: Omit<BadgeListItemProps, 'type'>[] = mock; // 데이터 fetch (정렬된 데이터 수신 가정)
+    const data: NotiItemType[] = mock; // 데이터 fetch (정렬된 데이터 수신 가정)
     setNotiList(data);
   }, []);
 
@@ -69,14 +46,7 @@ const NotificationPage = () => {
       <Header text='알림' headerType='hamburger' />
       <Ol>
         {notiList.length !== 0 ? (
-          notiList.map((item, index) => (
-            <BadgeListItem
-              key={index}
-              type='notice'
-              {...item}
-              time={formatTimeGap(new Date(), new Date(item.time))}
-            />
-          ))
+          notiList.map((item) => <NotiItem key={item.id} {...item} />)
         ) : (
           <Span>알림이 없어요.</Span>
         )}

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -60,22 +60,26 @@ const NotificationPage = () => {
   const [notiList, setNotiList] = useState<Omit<BadgeListItemProps, 'type'>[]>([]);
 
   useEffect(() => {
-    const data = mock; // 데이터 fetch
-    setNotiList(
-      data.map((item) => {
-        const time = formatTimeGap(new Date(), new Date(item.time));
-        return { ...item, time };
-      }),
-    );
+    const data: Omit<BadgeListItemProps, 'type'>[] = mock; // 데이터 fetch (정렬된 데이터 수신 가정)
+    setNotiList(data);
   }, []);
 
   return (
     <Layout>
       <Header text='알림' headerType='hamburger' />
-        {notiList.map((item) => (
-            <BadgeListItem type='notice' {...item} />
-        ))}
       <Ol>
+        {notiList.length !== 0 ? (
+          notiList.map((item, index) => (
+            <BadgeListItem
+              key={index}
+              type='notice'
+              {...item}
+              time={formatTimeGap(new Date(), new Date(item.time))}
+            />
+          ))
+        ) : (
+          <Span>알림이 없어요.</Span>
+        )}
       </Ol>
     </Layout>
   );

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -90,11 +90,22 @@ export default NotificationPage;
 const Layout = styled.div`
   display: flex;
   flex-flow: column nowrap;
+
+  height: 100%;
 `;
 const Ol = styled.ol`
   display: flex;
   flex-flow: column nowrap;
   gap: 0.62rem;
 
+  flex: 1;
+  overflow-y: scroll;
+
   margin: 0.94rem 5%;
+`;
+const Span = styled.span`
+  margin: auto;
+
+  ${({ theme }) => theme.fonts.body}
+  color: ${({ theme }) => theme.colors.black200};
 `;

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -72,13 +72,11 @@ const NotificationPage = () => {
   return (
     <Layout>
       <Header text='알림' headerType='hamburger' />
-      <Ul>
         {notiList.map((item) => (
-          <li key={item.time}>
             <BadgeListItem type='notice' {...item} />
-          </li>
         ))}
-      </Ul>
+      <Ol>
+      </Ol>
     </Layout>
   );
 };
@@ -89,7 +87,7 @@ const Layout = styled.div`
   display: flex;
   flex-flow: column nowrap;
 `;
-const Ul = styled.ul`
+const Ol = styled.ol`
   display: flex;
   flex-flow: column nowrap;
   gap: 0.62rem;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -9,6 +9,14 @@ declare type Toast = {
   content: string;
   kind?: 'default' | 'success' | 'error';
 };
+declare type BadgeItem = {
+  imgUrl: string;
+  caption: string;
+  time: string;
+  message: string;
+  isRead: boolean;
+};
+
 declare interface InputProps {
   title: string;
   placeholder: string;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -9,13 +9,6 @@ declare type Toast = {
   content: string;
   kind?: 'default' | 'success' | 'error';
 };
-declare type BadgeItem = {
-  imgUrl: string;
-  caption: string;
-  time: string;
-  message: string;
-  isRead: boolean;
-};
 
 declare interface InputProps {
   title: string;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -13,3 +13,28 @@ export const formatDate = (date: Date): string => {
     })
     .replace(/(\d{4}). (\d{2}). (\d{2})./, '$1-$2-$3');
 };
+/**
+ * x와 y의 시간 차를 특정 형식으로 반환합니다.
+ * @param x new Date()로 생성한 객체
+ * @param y new Date()로 생성한 객체
+ * @returns "n년" | "n개월" | "n일" | "n시간" | "n분" | "n초" | "방금"
+ */
+export const formatTimeGap = (x: Date, y: Date): string => {
+  const secondMs = 1000;
+  const minuteMs = secondMs * 60;
+  const hourMs = minuteMs * 60;
+  const dayMs = hourMs * 24;
+  const monthMs = dayMs * 31;
+  const yearMs = monthMs * 12;
+
+  let diffMs = x.getTime() - y.getTime();
+  if (diffMs < 0) diffMs *= -1;
+
+  if (diffMs >= yearMs) return `${diffMs / yearMs}년`;
+  if (diffMs >= monthMs) return `${diffMs / monthMs}개월`;
+  if (diffMs >= dayMs) return `${diffMs / dayMs}일`;
+  if (diffMs >= hourMs) return `${diffMs / hourMs}시간`;
+  if (diffMs >= minuteMs) return `${diffMs / minuteMs}분`;
+  if (diffMs >= secondMs) return `${diffMs / secondMs}초`;
+  return '방금';
+};

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -14,27 +14,24 @@ export const formatDate = (date: Date): string => {
     .replace(/(\d{4}). (\d{2}). (\d{2})./, '$1-$2-$3');
 };
 /**
- * x와 y의 시간 차를 특정 형식으로 반환합니다.
- * @param x new Date()로 생성한 객체
- * @param y new Date()로 생성한 객체
+ * a와 b의 시간 차를 특정 형식으로 반환합니다.
+ * @param a new Date()로 생성한 객체
+ * @param b new Date()로 생성한 객체
  * @returns "n년" | "n개월" | "n일" | "n시간" | "n분" | "n초" | "방금"
  */
-export const formatTimeGap = (x: Date, y: Date): string => {
-  let diff: number = 0;
-  let time: string = '방금';
+export const formatTimeGap = (a: Date, b: Date): string => {
+  const epochDate = new Date('1970-01-01');
+  const diffDate = new Date(Math.abs(a.getTime() - b.getTime()));
 
-  diff = x.getFullYear() - y.getFullYear();
-  if (diff !== 0) time = '년';
-  diff = x.getMonth() - y.getMonth();
-  if (diff !== 0) time = '개월';
-  diff = x.getDate() - y.getDate();
-  if (diff !== 0) time = '일';
-  diff = x.getHours() - y.getHours();
-  if (diff !== 0) time = '시간';
-  diff = x.getMinutes() - y.getMinutes();
-  if (diff !== 0) time = '분';
-  diff = x.getSeconds() - y.getSeconds();
-  if (diff !== 0) time = '초';
+  const diffList = [
+    { diff: epochDate.getFullYear() - diffDate.getFullYear(), unit: '년' },
+    { diff: epochDate.getMonth() - diffDate.getMonth(), unit: '개월' },
+    { diff: epochDate.getDate() - diffDate.getDate(), unit: '일' },
+    { diff: epochDate.getHours() - diffDate.getHours(), unit: '시간' },
+    { diff: epochDate.getMinutes() - diffDate.getMinutes(), unit: '분' },
+    { diff: epochDate.getSeconds() - diffDate.getSeconds(), unit: '초' },
+  ];
 
-  return diff ? `${Math.abs(diff)}${time}` : time;
+  const timeGap = diffList.find((diffItem) => diffItem.diff !== 0);
+  return timeGap ? `${Math.abs(timeGap.diff)}${timeGap.unit}` : '방금';
 };

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -20,21 +20,21 @@ export const formatDate = (date: Date): string => {
  * @returns "n년" | "n개월" | "n일" | "n시간" | "n분" | "n초" | "방금"
  */
 export const formatTimeGap = (x: Date, y: Date): string => {
-  const secondMs = 1000;
-  const minuteMs = secondMs * 60;
-  const hourMs = minuteMs * 60;
-  const dayMs = hourMs * 24;
-  const monthMs = dayMs * 31;
-  const yearMs = monthMs * 12;
+  let diff: number = 0;
+  let time: string = '방금';
 
-  let diffMs = x.getTime() - y.getTime();
-  if (diffMs < 0) diffMs *= -1;
+  diff = x.getFullYear() - y.getFullYear();
+  if (diff !== 0) time = '년';
+  diff = x.getMonth() - y.getMonth();
+  if (diff !== 0) time = '개월';
+  diff = x.getDate() - y.getDate();
+  if (diff !== 0) time = '일';
+  diff = x.getHours() - y.getHours();
+  if (diff !== 0) time = '시간';
+  diff = x.getMinutes() - y.getMinutes();
+  if (diff !== 0) time = '분';
+  diff = x.getSeconds() - y.getSeconds();
+  if (diff !== 0) time = '초';
 
-  if (diffMs >= yearMs) return `${diffMs / yearMs}년`;
-  if (diffMs >= monthMs) return `${diffMs / monthMs}개월`;
-  if (diffMs >= dayMs) return `${diffMs / dayMs}일`;
-  if (diffMs >= hourMs) return `${diffMs / hourMs}시간`;
-  if (diffMs >= minuteMs) return `${diffMs / minuteMs}분`;
-  if (diffMs >= secondMs) return `${diffMs / secondMs}초`;
-  return '방금';
+  return diff ? `${Math.abs(diff)}${time}` : time;
 };


### PR DESCRIPTION
## 🔎 What is this PR?

### Figma: 프로토타입 캡처

<table>
  <tr>
    <th>알림 페이지</th>
  </tr>
  <tr>
    <td width="250px">
      <img src="https://github.com/user-attachments/assets/5f68ae9e-7d66-4074-9b1e-098f300c232c" />
    </td>
  </tr>
</table>

## ✨ 설명

- 관련 PR: #52
- 디자이너 부재 중 이슈로 프로토타입에서 디자인하지 않은 부분은 임의로 작업했습니다.
  - 알림이 없는 경우
  - 알림 아이템 읽음 처리 기준
  - 알림 아이템 클릭 시 액션
1. 알림이 없는 경우
   - "알림이 없어요." 텍스트를 표시합니다.
2. 알림이 있는 경우
   - #58 
     a와 b의 시간 차를 특정 형식의 string으로 반환합니다. 알림 페이지에서는 "30분" 등의 현재 시각과 알림 생성 시각의 차를 계산하기 위해 사용했습니다. 혹시 나중에 다른 곳에서도 쓸 일이 있을까 싶어 util로 개발했습니다.
   - BadgeListItem 공통 컴포넌트의 UI → NotiItem 컴포넌트에서 알림 페이지 전용 기능 처리 → 알림 페이지에서 map 함수로 나열하는 구조입니다.
   - 알림 아이템 클릭 시 navigate
     알림 아이템을 클릭하면 읽은 알림일 경우 바로 페이지 이동하고, 안 읽은 알림일 경우 읽음 처리하고 페이지 이동합니다.
   - 알림 아이템 클릭 시 읽음 처리
     알림 아이템을 클릭하면 로컬에서 상태를 업데이트하여 읽음 디자인으로 re-render되도록 했습니다. 서버에 읽음 PATCH 요청 후 새로고침은 하지 않을 예정입니다.

## 📷 스크린샷

<table>
  <tr>
    <th>알림이 없는 경우</th>
    <th>알림이 있는 경우</th>
    <th>아이템 클릭 시 navigate</th>
    <th>아이템 클릭 시 읽음 처리</th>
  </tr>
  <tr>
    <td width="25%">
      <img src="https://github.com/user-attachments/assets/bfd51f16-9eaa-47da-a8ad-bd76dbcd4fc1" />
    </td>
    <td width="25%">
      <img src="https://github.com/user-attachments/assets/eb47f3c0-92eb-4510-92cf-6f83ebdeaadf" />
    </td>
    <td width="25%">
      <img src="https://github.com/user-attachments/assets/7fe89a53-1b45-4f95-9872-6ad9d7781742" />
    </td>
    <td width="25%">
      <img src="https://github.com/user-attachments/assets/44eff0d0-8ae4-4ea0-9463-c2ac147d9be0" />
    </td>
  </tr>
</table>

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청

- @rwaeng 님께서 관련 공통 컴포넌트 #52 를 저의 요청으로 작업해주셔서 리뷰어를 아령 님으로 지정했습니다.
- BadgeListItem 컴포넌트의 수정을 최대한 지양했으나, `type='notice'`일 경우 `SMessage`에서 읽음 여부에 따라 `color`가 달라지지 않아 코드를 수정했습니다. 또, 공통 컴포넌트를 활용하려다 보니 props를 일일히 지정할 필요가 생겨 props 관련도 수정하였습니다.