### PR TITLE
버튼 컴포넌트, 버튼 배경 컴포넌트 (공통)

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -19,7 +19,7 @@ const SButton = styled.button`
   justify-content: center;
   align-items: center;
 
-  width: 19.6875rem;
+  width: 100%;
   padding: 0.9375rem 0.3125rem;
 
   border-radius: 0.9375rem;

--- a/src/components/common/ButtonBackground.tsx
+++ b/src/components/common/ButtonBackground.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+const ButtonBackground = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <>
+      <Blank />
+      <Layout>{children}</Layout>
+    </>
+  );
+};
+
+export default ButtonBackground;
+
+const Blank = styled.div`
+  height: 5.9375rem;
+`;
+const Layout = styled.div`
+  display: flex;
+  position: fixed;
+  bottom: 0;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  padding: 0.9375rem 1.875rem 1.875rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;

--- a/src/components/common/ButtonBackground.tsx
+++ b/src/components/common/ButtonBackground.tsx
@@ -1,10 +1,15 @@
 import styled from 'styled-components';
 
-const ButtonBackground = ({ children }: { children: React.ReactNode }) => {
+type ButtonBackgroundProps = {
+  children: React.ReactNode;
+  color?: string;
+};
+
+const ButtonBackground = ({ children, color }: ButtonBackgroundProps) => {
   return (
     <>
       <Blank />
-      <Layout>{children}</Layout>
+      <Layout color={color}>{children}</Layout>
     </>
   );
 };
@@ -14,7 +19,7 @@ export default ButtonBackground;
 const Blank = styled.div`
   height: 5.9375rem;
 `;
-const Layout = styled.div`
+const Layout = styled.div<{ color: string | undefined }>`
   display: flex;
   position: fixed;
   bottom: 0;
@@ -24,5 +29,5 @@ const Layout = styled.div`
   width: 100%;
   padding: 0.9375rem 1.875rem 1.875rem;
 
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme, color }) => color || theme.colors.white};
 `;


### PR DESCRIPTION
## 🔎 What is this PR?

Resolves #65 

## ✨ 설명
- 버튼 컴포넌트를 하단에 고정하기로 하면서 신경써야 할 부분이 늘어난 것 같아서 버튼 배경 컴포넌트를 공통 컴포넌트로 만들었습니다. 
 ```
// 버튼 배경 컴포넌트에 children으로 버튼 컴포넌트를 전달하면 됩니다.
<ButtonBackground>
   <Button>버튼</Button>
</ButtonBackground>
```
- 버튼 위치 수정이 필요할 거 같으면 패딩 수정 자유롭게 해주세요!
- 반응형을 고려하여 버튼 너비를 %로 바꿨으니 참고 부탁드립니다~!

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
