### PR TITLE
Popover 컴포넌트 (공통)

### DIFF
--- a/src/components/common/Popover.tsx
+++ b/src/components/common/Popover.tsx
@@ -1,0 +1,30 @@
+import MuiPopover from '@mui/material/Popover';
+
+interface PopOverProps {
+  anchorEl: HTMLElement | null;
+  isOpen: boolean;
+  onClose?: (event: React.MouseEvent<HTMLElement>) => void;
+  children: React.ReactNode;
+}
+
+const Popover = ({ anchorEl, isOpen, onClose, children }: PopOverProps) => {
+  return (
+    <MuiPopover
+      open={isOpen}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'left',
+      }}
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'left',
+      }}
+    >
+      {children}
+    </MuiPopover>
+  );
+};
+
+export default Popover;

--- a/src/hooks/usePopover.ts
+++ b/src/hooks/usePopover.ts
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 
-const usePopover = () => {
-  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+const usePopover = <T extends HTMLElement>() => {
+  const [anchorEl, setAnchorEl] = useState<T | null>(null);
 
-  const openPopover = (event: React.MouseEvent<HTMLDivElement>) => {
+  const openPopover = (event: React.MouseEvent<T>) => {
     event.stopPropagation();
     setAnchorEl(event.currentTarget);
   };
 
-  const closePopover = (event: React.MouseEvent<HTMLElement>) => {
+  const closePopover = (event: React.MouseEvent<T>) => {
     event.stopPropagation();
     setAnchorEl(null);
   };

--- a/src/hooks/usePopover.ts
+++ b/src/hooks/usePopover.ts
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+const usePopover = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+
+  const openPopover = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget);
+  };
+
+  const closePopover = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    setAnchorEl(null);
+  };
+
+  const isOpen = Boolean(anchorEl);
+
+  return {
+    anchorEl,
+    isOpen,
+    openPopover,
+    closePopover,
+  };
+};
+
+export default usePopover;


### PR DESCRIPTION
## 🔎 What is this PR?
Resolves #68 

- Tech spec: MUI 라이브러리의 Popover 컴포넌트 사용

## ✨ 설명

MUI 라이브러리의 Popover 컴포넌트를 사용해 커스텀 popover를 만들었습니다. [Popover](https://mui.com/material-ui/api/popover/)

### 사용 방법
1.  Popover 컴포넌트를 불러온다 (로컬 프로젝트에 있는 컴포넌트를 불러와주세요!! not mui..)
2. usePopover 훅을 사용하여 `anchorEl, isOpen, openPopover, closePopover`를 받아온다.
3. 다음과 같이 사용한다. 
    ```typescript
        <ButtonForPopover onClick = {openPopover}></ButtonForPopover> 
        <Popover anchorEl={anchorEl} isOpen={isOpen} onClose={closePopover}>
              <h1>popover 시 나타나는 컨텐츠 (children) 포함</h1>
        </Popover>

## 📷 스크린샷 (선택)
<img width="198" alt="image" src="https://github.com/user-attachments/assets/b7e960de-7196-4eca-a371-64d698f105a9">


## ☑️ 테스트 체크리스트

테스트 코드 작성하지 않음

## 💡 집중 리뷰 요청

Mui를 불러와야해서 부득이하게 75번 브랜치를 pull 받았습니다! 커밋내역에 포함될텐데, 그 부분 무시하시고 커밋 2개만 봐주시면 됩니다. 번거롭게 해드려 죄송합니다!
