### PR TITLE
로그인 API

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,5 +1,5 @@
+import { AxiosError } from 'axios';
 import client from '@src/apis/client';
-
 import authClient from './authClient';
 
 // const postLogin = async () => {
@@ -14,21 +14,24 @@ import authClient from './authClient';
 // };
 
 const postLogout = async () => {
-    try {
-      await authClient.post('auth/logout');
-    } catch (e) {
-      if (e instanceof Error) {
-        throw new Error(e.message);
-      }
+  try {
+    await authClient.post('auth/logout');
+  } catch (e) {
+    if (e instanceof Error) {
+      throw new Error(e.message);
     }
+  }
 };
 
 const postRefreshToken = async () => {
   try {
-    const res = await client.post('auth/token');
+    const cookie = document.cookie.split('=');
+    const res = await client.post('auth/token', {
+      refreshToken: cookie[1],
+    });
     localStorage.setItem('accessToken', res.data.accessToken);
   } catch (e) {
-    if (e instanceof Error) {
+    if (e instanceof AxiosError) {
       throw new Error(e.message);
     }
   }

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,47 @@
+import client from '@src/apis/client';
+
+import authClient from './authClient';
+
+// const postLogin = async () => {
+//   try {
+//     const res = await client.get('auth/success');
+//     console.log(res.data);
+//   } catch (e) {
+//     if (e instanceof Error) {
+//       throw new Error(e.message);
+//     }
+//   }
+// };
+
+const postLogout = async () => {
+    try {
+      await authClient.post('auth/logout');
+    } catch (e) {
+      if (e instanceof Error) {
+        throw new Error(e.message);
+      }
+    }
+};
+
+const postRefreshToken = async () => {
+  try {
+    const res = await client.post('auth/token');
+    localStorage.setItem('accessToken', res.data.accessToken);
+  } catch (e) {
+    if (e instanceof Error) {
+      throw new Error(e.message);
+    }
+  }
+};
+
+const deleteAccount = async () => {
+  try {
+    await authClient.delete('auth/token');
+  } catch (e) {
+    if (e instanceof Error) {
+      throw new Error(e.message);
+    }
+  }
+};
+
+export { postLogout, postRefreshToken, deleteAccount };

--- a/src/apis/authClient.ts
+++ b/src/apis/authClient.ts
@@ -1,5 +1,5 @@
-import apiUrl from "@src/constants/apiUrl";
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosInstance } from 'axios';
+import { apiUrl } from '@src/constants/apiUrl';
 
 const authClient: AxiosInstance = axios.create({
   baseURL: apiUrl,

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import apiUrl from '@src/constants/apiUrl';
+import { apiUrl } from '@src/constants/apiUrl';
 
 const client: AxiosInstance = axios.create({
   baseURL: apiUrl,

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,10 +1,10 @@
 import client from '@src/apis/client';
 import authClient from '@src/apis/authClient';
-import { onRequest, onResponse } from './interceptor';
+import { onError, onRequest, onResponse } from './interceptor';
 
 client.interceptors.response.use(onResponse);
 
 authClient.interceptors.request.use(onRequest);
-authClient.interceptors.response.use(onResponse);
+authClient.interceptors.response.use(onResponse, onError);
 
 export { client, authClient };

--- a/src/apis/interceptor.ts
+++ b/src/apis/interceptor.ts
@@ -1,4 +1,13 @@
-import { AxiosHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import {
+  AxiosError,
+  AxiosHeaders,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import { ROUTE_PATH } from '@src/constants/routePath';
+import { postRefreshToken } from '@src/apis/auth';
+import authClient from '@src/apis/authClient';
+import { isTokenExpiredMessage } from '@src/utils/validators';
 
 const onRequest = (
   config: InternalAxiosRequestConfig,
@@ -25,4 +34,35 @@ const onResponse = (response: AxiosResponse): AxiosResponse => {
   return response;
 };
 
-export { onRequest, onResponse };
+const onError = async (error: AxiosError) => {
+  const { config, response } = error;
+  if (!config || !response) return Promise.reject(error);
+
+  if (config.sent) {
+    return Promise.reject(error);
+  }
+  config.sent = true;
+
+  const { status, data } = response;
+
+  if (status === 401 && isTokenExpiredMessage(data)) {
+    try {
+      await postRefreshToken();
+
+      const accessToken = localStorage.getItem('accessToken');
+      if (accessToken) {
+        authClient.defaults.headers.Authorization = `Bearer ${accessToken}`;
+        config.headers.Authorization = `Bearer ${accessToken}`;
+        return authClient(config);
+      }
+    } catch (e) {
+      localStorage.removeItem('accessToken');
+      window.location.replace(ROUTE_PATH.signIn);
+      return Promise.reject(e);
+    }
+  }
+
+  return Promise.reject(error);
+};
+
+export { onRequest, onResponse, onError };

--- a/src/constants/apiUrl.ts
+++ b/src/constants/apiUrl.ts
@@ -1,3 +1,4 @@
 const apiUrl = process.env.REACT_APP_API_URL;
+const kakaoUrl = process.env.REACT_APP_KAKAO_URL;
 
-export default apiUrl;
+export { apiUrl, kakaoUrl };

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -6,6 +6,7 @@ export const ROUTE_PATH = {
   /* auth */
   root: '/',
   signIn: '/sign-in',
+  redirection: '/auth/success',
   /* library */
   library: '/library',
   libraryMember: '/library/:memberId',

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 import { ReactComponent as KakaoButton } from '@src/assets/images/login/kakao_login.svg';
 import { ReactComponent as Logo } from '@src/assets/images/login/bookwoori_logo.svg';
+import { kakaoUrl } from '@src/constants/apiUrl';
 
 const LoginPage = () => {
   return (
     <Layout>
       <SLogo />
-      <Button>
+      <Button href={kakaoUrl}>
         <KakaoButton />
       </Button>
     </Layout>
@@ -29,7 +30,7 @@ const SLogo = styled(Logo)`
   width: 18.75rem;
   height: 4.0625rem;
 `;
-const Button = styled.button`
+const Button = styled.a`
   display: flex;
   align-items: center;
 

--- a/src/pages/login/RedirectionPage.tsx
+++ b/src/pages/login/RedirectionPage.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import { useSearchParams } from 'react-router-dom';
+import { ROUTE_PATH } from '@src/constants/routePath';
+import Spinner from '@src/components/common/Spinner';
+
+
+const RedirectionPage = () => {
+  const [searchParams] = useSearchParams();
+  const accessToken = searchParams.get('accessToken');
+
+  if (accessToken) {
+    localStorage.setItem('accessToken', accessToken);
+    window.location.replace(ROUTE_PATH.root);
+  } else {
+    window.location.replace(ROUTE_PATH.signIn);
+  }
+
+  return (
+    <Layout>
+      <Spinner />
+    </Layout>
+  );
+};
+
+export default RedirectionPage;
+
+const Layout = styled.div`
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -17,6 +17,12 @@ const ChannelListPage = React.lazy(
   () => import('@src/pages/channel/ChannelListPage'),
 );
 
+/* auth */
+const LoginPage = React.lazy(() => import('@src/pages/login/LoginPage'));
+const RedirectionPage = React.lazy(
+  () => import('@src/pages/login/RedirectionPage'),
+);
+
 const router = createBrowserRouter([
   {
     element: (
@@ -42,8 +48,12 @@ const router = createBrowserRouter([
         element: <h1>Root</h1>,
       },
       {
+        path: ROUTE_PATH.redirection,
+        element: <RedirectionPage />,
+      },
+      {
         path: ROUTE_PATH.signIn,
-        element: <h1>Sign In Page</h1>,
+        element: <LoginPage />,
       },
       /* library */
       {

--- a/src/types/axios.ts
+++ b/src/types/axios.ts
@@ -1,0 +1,7 @@
+import 'axios';
+
+declare module 'axios' {
+  interface InternalAxiosRequestConfig {
+    sent?: boolean;
+  }
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,11 +1,3 @@
-import 'axios';
-
-declare module 'axios' {
-  interface InternalAxiosRequestConfig {
-    sent?: boolean;
-  }
-}
-
 declare type ModalTransition = 'open' | 'close';
 declare type Modal = {
   content: React.ReactNode;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,3 +1,11 @@
+import 'axios';
+
+declare module 'axios' {
+  interface InternalAxiosRequestConfig {
+    sent?: boolean;
+  }
+}
+
 declare type ModalTransition = 'open' | 'close';
 declare type Modal = {
   content: React.ReactNode;

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -6,3 +6,8 @@ export const isBase64Encoded = (str: string): boolean => {
     return false; // 디코딩 실패 시 Base64가 아님
   }
 };
+
+// 후에 에러 타입 반영 수정
+export const isTokenExpiredMessage = (data: any): boolean => {
+  return data?.message === '만료된 액세스 토큰입니다.';
+};


### PR DESCRIPTION
## 🔎 What is this PR?

- Product spec: 카카오 로그인
  명세서의 주소로 post 하는 과정 없이 백이 전달해준 카카오 로그인 주소로 바로 접속 후 리다이렉션 페이지에서 access 토큰을 읽어오는 방식. refreshToken의 경우 쿠키를 사용할 예정이었으나 추후 변경 가능.

## ✨ 설명
### 리다이렉션 페이지
- 공통 컴포넌트 스피너 사용
- accessToken 저장

### onError
- request interceptor 작성

### auth.ts
- 일단 try...catch문으로 작성했는데 에러 처리 방법에 따라 수정할 수도 있을 듯 합니다,,,

### 라우팅 주소 변경
- signUp -> redirection
- /sign-up -> /auth/success

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
@yyeonzu 접근 권한 작업하셔서 리뷰어 설정합니다!

토큰 재발급 부분은 미완입니다
로그인 부분 더 빨리 올렸어야 하는데 죄송합니다,,, 

하나 궁금한 점이 있는데 에러 타입 정의할 때 어떤 식으로 하시나요!?