### PR TITLE
공통 컴포넌트: Header

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -2,44 +2,36 @@ import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import useSideBar from '@src/hooks/useSideBar';
 import useServerbar from '@src/hooks/useServerbar';
+import Serverbar from '@src/components/common/Serverbar';
 import { ReactComponent as Hamburger } from '@src/assets/icons/menu.svg';
 import { ReactComponent as Back } from '@src/assets/icons/left_arrow.svg';
 import { ReactComponent as Users } from '@src/assets/icons/users.svg';
-import Serverbar from '@src/components/common/Serverbar';
 
-interface headerProps {
-  className?: string;
+interface HeaderProps {
   text: string;
   headerType: 'hamburger' | 'back' | 'server';
 }
 
-const Header = ({ className, text, headerType }: headerProps) => {
-  const navigate = useNavigate();
-  const { openSideBar } = useSideBar();
-  const { openServerbar } = useServerbar();
+const renderButton = (type: string, onClick: () => void, Icon: React.FC) => (
+  <Button type='button' onClick={onClick} aria-label={type}>
+    <Icon />
+  </Button>
+);
 
-  const handleClick = () => {
-    navigate(-1);
-  };
+const Header = ({ text, headerType }: HeaderProps) => {
+  const navigate = useNavigate();
+  const handleClick = () => navigate(-1);
+  const { openServerbar } = useServerbar();
+  const { openSideBar } = useSideBar();
 
   return (
-    <Layout className={className}>
-      {headerType === 'back' ? (
-        <Button type='button' onClick={handleClick} aria-label={headerType}>
-          <Back />
-        </Button>
-      ) : (
-        <Button type='button' onClick={openServerbar} aria-label={headerType}>
-          <Hamburger />
-        </Button>
-      )}
+    <Layout>
+      {headerType === 'back' && renderButton('back', handleClick, Back)}
+      {(headerType === 'hamburger' || headerType === 'server') &&
+        renderButton('hamburger', openServerbar, Hamburger)}
       <Serverbar />
       <Label>{text}</Label>
-      {headerType === 'server' && (
-        <Button type='button' onClick={openSideBar}>
-          <Users />
-        </Button>
-      )}
+      {headerType === 'server' && renderButton('server', openSideBar, Users)}
     </Layout>
   );
 };

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -44,7 +44,7 @@ const Layout = styled.header`
   justify-content: space-between;
   position: fixed;
   top: 0;
-  z-index: 100;
+  z-index: ${({theme}) => theme.zIndex.header};
 
   width: 100%;
   height: 4.375rem;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -23,35 +23,36 @@ const Header = ({ className, text, headerType }: headerProps) => {
   };
 
   return (
-    <SHeader className={className}>
+    <Layout className={className}>
       {headerType === 'back' ? (
-        <SButton type='button' onClick={handleClick} aria-label={headerType}>
+        <Button type='button' onClick={handleClick} aria-label={headerType}>
           <Back />
-        </SButton>
+        </Button>
       ) : (
-        <SButton type='button' onClick={openServerbar} aria-label={headerType}>
+        <Button type='button' onClick={openServerbar} aria-label={headerType}>
           <Hamburger />
-        </SButton>
+        </Button>
       )}
       <Serverbar />
-      <SLabel>{text}</SLabel>
+      <Label>{text}</Label>
       {headerType === 'server' && (
-        <SButton type='button' onClick={openSideBar}>
+        <Button type='button' onClick={openSideBar}>
           <Users />
-        </SButton>
+        </Button>
       )}
-    </SHeader>
+    </Layout>
   );
 };
 
 export default Header;
 
-const SHeader = styled.header`
+const Layout = styled.header`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  position: sticky;
+  position: fixed;
   top: 0;
+  z-index: 100;
 
   width: 100%;
   height: 4.375rem;
@@ -60,7 +61,7 @@ const SHeader = styled.header`
   background: ${({ theme }) => theme.colors.neutral0};
 `;
 
-const SLabel = styled.label`
+const Label = styled.label`
   position: absolute;
   top: 50%;
   left: 50%;
@@ -71,7 +72,7 @@ const SLabel = styled.label`
   text-align: center;
 `;
 
-const SButton = styled.button`
+const Button = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/channel/ChannelListPage.tsx
+++ b/src/pages/channel/ChannelListPage.tsx
@@ -53,7 +53,7 @@ const ChannelListPage = () => {
 
   return (
     <>
-      <SHeader headerType='server' text={serverInfo?.name ?? '서버'} />
+      <Header headerType='server' text={serverInfo?.name ?? '서버'} />
       <SLayout>
         <SButtonContainer>
           {buttonData.map((buttonItem) => (
@@ -102,9 +102,6 @@ const ChannelListPage = () => {
 
 export default ChannelListPage;
 
-const SHeader = styled(Header)`
-  z-index: 1;
-`;
 const SLayout = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/pages/channel/ChannelPage.tsx
+++ b/src/pages/channel/ChannelPage.tsx
@@ -158,7 +158,7 @@ const ChannelPage = () => {
 
   return (
     <>
-      <SHeader text={channelName ?? ''} headerType='back' />
+      <Header text={channelName ?? ''} headerType='back' />
       <Container ref={containerRef}>
         {totalMessageCount > 8 && <div ref={ref} style={{ height: '20px' }} />}
         {Object.entries(chattings)
@@ -184,10 +184,6 @@ const ChannelPage = () => {
 };
 
 export default ChannelPage;
-
-const SHeader = styled(Header)`
-  z-index: 1;
-`;
 
 const Container = styled.div`
   position: relative;

--- a/src/pages/chatting/ChattingPage.tsx
+++ b/src/pages/chatting/ChattingPage.tsx
@@ -128,7 +128,7 @@ const ChattingPage = () => {
 
   return (
     <>
-      <SHeader text={roomInfo?.title ?? ''} headerType='back' />
+      <Header text={roomInfo?.title ?? ''} headerType='back' />
       <SLayout ref={chatRef}>
         <div ref={targetRef} />
         <Container>
@@ -173,10 +173,6 @@ const ChattingPage = () => {
 
 export default ChattingPage;
 
-const SHeader = styled(Header)`
-  position: fixed;
-  z-index: 1;
-`;
 const SLayout = styled.div`
   display: flex;
   position: relative;

--- a/src/pages/climbing/ClimbingEditPage.tsx
+++ b/src/pages/climbing/ClimbingEditPage.tsx
@@ -78,7 +78,7 @@ const ClimbingEditPage = () => {
 
   return (
     <>
-      <SHeader text='등반 편집하기' headerType='back' />
+      <Header text='등반 편집하기' headerType='back' />
       <SLayout>
         <InputText
           title='등반 이름'
@@ -146,9 +146,6 @@ const ClimbingEditPage = () => {
 
 export default ClimbingEditPage;
 
-const SHeader = styled(Header)`
-  z-index: 2;
-`;
 const SLayout = styled.form`
   display: flex;
   flex-direction: column;

--- a/src/pages/climbing/ClimbingProgressPage.tsx
+++ b/src/pages/climbing/ClimbingProgressPage.tsx
@@ -10,7 +10,7 @@ const ClimbingProgressPage = ({ name: headerText }: { name: string }) => {
 
   return (
     <>
-      <SHeader text={headerText} headerType='back' />
+      <Header text={headerText} headerType='back' />
       <Layout>
         <Wrapper>
           <ClimbingDescription />
@@ -23,9 +23,6 @@ const ClimbingProgressPage = ({ name: headerText }: { name: string }) => {
 
 export default ClimbingProgressPage;
 
-const SHeader = styled(Header)`
-  z-index: 1;
-`;
 const Layout = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/pages/climbing/ClimbingTerminatePage.tsx
+++ b/src/pages/climbing/ClimbingTerminatePage.tsx
@@ -15,7 +15,7 @@ const ClimbingTerminatePage = ({ name: headerText }: { name: string }) => {
 
   return (
     <>
-      <HeaderWithZIndex text={headerText} headerType='back' />
+      <Header text={headerText} headerType='back' />
       <Container>
         <SegmentedButton onSegmentChange={handleSegmentChange} />
         {selectedView === 'climbing' && <ClimbingBoard />}
@@ -26,10 +26,6 @@ const ClimbingTerminatePage = ({ name: headerText }: { name: string }) => {
 };
 
 export default ClimbingTerminatePage;
-
-const HeaderWithZIndex = styled(Header)`
-  z-index: 1;
-`;
 
 const Container = styled.div`
   display: flex;

--- a/src/pages/userSettings/SettingsPage.tsx
+++ b/src/pages/userSettings/SettingsPage.tsx
@@ -45,7 +45,7 @@ const SettingsPage = () => {
 
   return (
     <>
-      <SHeader text='설정' headerType='hamburger' />
+      <Header text='설정' headerType='hamburger' />
       <SLayout>
         <UserProfile />
         <SContainer>
@@ -63,9 +63,6 @@ const SettingsPage = () => {
 
 export default SettingsPage;
 
-const SHeader = styled(Header)`
-  z-index: 1;
-`;
 const SLayout = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -20,7 +20,6 @@ const GlobalStyle = createGlobalStyle`
       width: 100vw;
       height: 100vh;
     }
-    padding-top: 4.375rem;
     background-color: ${({ theme }) => theme.colors.neutral50};
     ${({ theme }) => theme.fonts.body}
   }

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -20,6 +20,7 @@ const GlobalStyle = createGlobalStyle`
       width: 100vw;
       height: 100vh;
     }
+    padding-top: 4.375rem;
     background-color: ${({ theme }) => theme.colors.neutral50};
     ${({ theme }) => theme.fonts.body}
   }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -93,6 +93,7 @@ const gap = {
 const zIndex = {
   toast: '900',
   modal: '800',
+  header: '100',
 } as const;
 
 export type ColorsTypes = typeof colors;


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ 설명
### position 변경
sticky -> fixed 변경
- fixed 변경으로 전체 body에 패딩을 설정했습니다.  `padding-top: 4.375rem;`
  헤더를 사용하지 않는 부분이 로그인, 책 검색을 제외하고는 없는 것 같아서 전체 body에 추가했는데 전체 body에 패딩을 추가하는 게 괜찮을지 의견 부탁드립니다! 
이 경우
  - `height: calc(100% - 4.375rem);`를 사용해서 페이지 전체 높이를 계산한 경우 수정이 필요합니다.
  - 책 검색 페이지에서 검색 헤더 position을 fixed로 변경이 필요합니다.
  - 로그인 페이지 수정이 필요합니다.
- 전체 body에 패딩을 추가하지 않는다면 공통 레이아웃에서 헤더 있는 페이지/없는 페이지로 나눈 뒤 패딩을 추가하거나 Header.tsx에 높이를 준 div를 추가하는 방법으로 해결할 수 있을 것 같습니다.

### 코드 가독성 개선
타입에 따라 달라지는 버튼 부분의 조건부 렌더링이 조금 복잡해 보여 코드를 수정했습니다.

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청