### PR TITLE
공통 컴포넌트: Segmented Button

### DIFF
--- a/src/components/common/SegmentedButton.tsx
+++ b/src/components/common/SegmentedButton.tsx
@@ -1,9 +1,25 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
+/**
+ * Props for SegmentedButton component
+ * @template T - Type of value in config, must be string
+ */
 interface SegmentedButtonProps<T extends string> {
+  /**
+   * Configuration for segmented buttons.
+   * Each object includes a value and a label.
+   */
   config: { value: T; label: string }[];
+  /**
+   * Callback function that is called when a button is clicked.
+   * @param value - Value of the clicked button
+   */
   onSegmentChange: (value: T) => void;
+  /**
+   * Default value of the segmented button.
+   * If not provided, the first value in config will be selected.
+   */
   defaultValue?: T;
 }
 

--- a/src/components/common/SegmentedButton.tsx
+++ b/src/components/common/SegmentedButton.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+interface SegmentedButtonProps<T extends string> {
+  config: { value: T; label: string }[];
+  onSegmentChange: (value: T) => void;
+  defaultValue?: T;
+}
+
+const SegmentedButton = <T extends string>({
+  config,
+  onSegmentChange,
+  defaultValue,
+}: SegmentedButtonProps<T>) => {
+  const initialValue = defaultValue ?? config[0].value;
+
+  const [selected, setSelected] = useState<T>(initialValue);
+
+  const handleChange = useCallback(
+    (value: T) => {
+      setSelected(value);
+      onSegmentChange(value);
+    },
+    [onSegmentChange],
+  );
+
+  const selectedIndex = config.findIndex((option) => option.value === selected);
+
+  return (
+    <ButtonsContainer length={config.length}>
+      <SelectedBackground position={selectedIndex} length={config.length} />
+      {config.map((option) => (
+        <Button
+          key={option.value}
+          isSelected={selected === option.value}
+          onClick={() => handleChange(option.value)}
+        >
+          {option.label}
+        </Button>
+      ))}
+    </ButtonsContainer>
+  );
+};
+
+export default SegmentedButton;
+
+// Styled Components
+const ButtonsContainer = styled.div<{ length: number }>`
+  position: relative;
+  display: flex;
+  border: solid 0.1rem ${({ theme }) => theme.colors.blue300};
+  border-radius: ${({ theme }) => theme.rounded['24']};
+  background-color: ${({ theme }) => theme.colors.neutral0};
+  overflow: hidden;
+
+  button {
+    flex: ${({ length }) => `0 0 calc(100% / ${length})`};
+  }
+`;
+
+const SelectedBackground = styled.div<{ position: number; length: number }>`
+  position: absolute;
+  top: ${({ theme }) => theme.padding['2']};
+  bottom: ${({ theme }) => theme.padding['2']};
+  left: ${({ position, length, theme }) =>
+    `calc(${position * (100 / length)}% + ${theme.padding['2']})`};
+  width: ${({ length, theme }) =>
+    `calc(100% / ${length} - ${theme.padding['4']} )`};
+  background-color: ${({ theme }) => theme.colors.blue500};
+  border-radius: ${({ theme }) => theme.rounded['24']};
+  transition:
+    left 0.3s ease-in-out,
+    background-color 0.3s ease-in-out;
+`;
+
+const Button = styled.button<{ isSelected: boolean }>`
+  position: relative;
+  flex: 1;
+  padding: 0.5rem;
+  background-color: transparent;
+  color: ${({ isSelected, theme }) =>
+    isSelected ? theme.colors.neutral0 : theme.colors.blue500};
+  transition: color 0.3s ease;
+`;

--- a/src/components/common/SegmentedButton.tsx
+++ b/src/components/common/SegmentedButton.tsx
@@ -28,7 +28,11 @@ const SegmentedButton = <T extends string>({
   onSegmentChange,
   defaultValue,
 }: SegmentedButtonProps<T>) => {
-  const initialValue = defaultValue ?? config[0].value;
+  const initialValue =
+    defaultValue !== undefined &&
+    config.some((option) => option.value === defaultValue)
+      ? defaultValue
+      : config[0].value;
 
   const [selected, setSelected] = useState<T>(initialValue);
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -64,6 +64,7 @@ const fonts = {
 } as const;
 
 const rounded = {
+  2: '0.125rem',
   4: '0.25rem',
   6: '0.375rem',
   8: '0.5rem',
@@ -73,6 +74,7 @@ const rounded = {
 } as const;
 
 const padding = {
+  2: '0.125rem',
   4: '0.25rem',
   6: '0.375rem',
   8: '0.5rem',


### PR DESCRIPTION
## 🔎 What is this PR?

Resolves #233

## ✨ 설명

- 회의록에서 Filter로 명명했던 컴포넌트를 SegmentedButton 컴포넌트로 이름 변경했습니다! 다음 블로그를 참고했습니다. [탭과 세그먼트 버튼의 차이점](https://brunch.co.kr/@bf6b5403fa344c4/3) 
- Props로 `config`와 `onSegmentChange`를 받아옵니다.
- `defaultValue`는 선택사항으로, 제네릭으로 타입 지정했으니 편한 방식으로 지정해주시면 됩니다. 만약 선택하지 않으면 config의 0번 객체가 선택됩니다.
- JSDoc 주석으로 props 정보를 자세히 적어두었습니다.
- **디자인토큰의 rounded, padding에 2px(0.125rem)을 포함했습니다. 없으면 안될 것 같아요... ㅠㅠ**

## 📷 스크린샷 (선택)
![segmented_buttons_2](https://github.com/user-attachments/assets/a3f09b35-6002-4a4b-be56-f7a40d5e23ed)
![segmented_buttons](https://github.com/user-attachments/assets/b12f18a9-b214-4084-bf81-4278af984237)

## ☑️ 테스트 체크리스트


## 💡 집중 리뷰 요청

- 혜린님이 JSDoc 주석 사용을 원하시는 것 같아서, 한 번 작성해보았습니다. 처음 작성해보는거라, GPT와 코파일럿의 도움을 좀 받았습니다. 😅 참고해주세요.
- JSDoc 주석과 관련된 추가 의문인데, 작성하다보니 오히려 코드 가독성이 떨어지나? 하는 고민이 들었습니다. 코드 살펴보시고 한 번 확인 부탁드립니다 ~!
