### PR TITLE
공통 컴포넌트: ExpandableList

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,9 +16,7 @@
     "es6": true
   },
   "settings": {
-    // React 버전을 자동으로 감지하도록 설정
     "react": { "version": "detect" },
-    // 경로 별칭 매핑 설정
     "import/resolver": {
       "alias": {
         "map": [["@src", "./src"]],
@@ -54,39 +52,32 @@
   ],
   "rules": {
     "import/extensions": [
-      "error", // "error": 이 규칙을 위반하면 오류로 처리
-      "ignorePackages", // "ignorePackages": 패키지 모듈을 가져올 때는 확장자를 검사하지 않음
-      { "js": "never", "jsx": "never", "ts": "never", "tsx": "never" } // JavaScript 및 TypeScript 파일의 확장자를 생략하도록 설정
+      "error",
+      "ignorePackages",
+      { "js": "never", "jsx": "never", "ts": "never", "tsx": "never" }
     ],
     "import/no-extraneous-dependencies": [
       "error",
-      // devDependencies 예외: 특정 파일 패턴에 대해 devDependencies에서 가져오는 것을 허용
       { "devDependencies": ["*.config.*", "*.setup.*", "**/*.test.tsx"] }
     ],
-    // 상대 경로 import 비허용
     "no-restricted-imports": ["error", { "patterns": ["..*"] }],
-    // JSX를 사용할 때 React를 반드시 import하지 않아도 됨
     "react/react-in-jsx-scope": "off",
-    // JSX 코드를 .jsx와 .tsx 파일에서만 사용할 수 있도록 제한
     "react/jsx-filename-extension": [
       "error",
       { "extensions": [".jsx", ".tsx"] }
     ],
-    // 함수형 컴포넌트를 화살표 함수나 함수 선언으로 정의할 수 있도록 지정
     "react/function-component-definition": [
       "error",
       { "namedComponents": ["arrow-function", "function-declaration"] }
     ],
-    // 컴포넌트.defaultProps{} 미사용 허용
     "react/require-default-props": "off",
-    // ...props 허용
     "react/jsx-props-no-spreading": "off",
-    // styled-components를 뒤에 선언할 수 있게 허용
     "no-use-before-define": "off",
-    // 화살표 함수의 중괄호 여부 스타일을 검사하지 않음
     "arrow-body-style": "off",
-    // id/htmlFor 또는 감싸는 방식 둘 다 허용
-    "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" }]
+    "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" }],
+    "import/prefer-default-export": "off",
+    "react/jsx-no-useless-fragment": "off",
+    "no-nested-ternary": "off"
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -77,7 +77,8 @@
     "jsx-a11y/label-has-associated-control": ["error", { "assert": "either" }],
     "import/prefer-default-export": "off",
     "react/jsx-no-useless-fragment": "off",
-    "no-nested-ternary": "off"
+    "no-nested-ternary": "off",
+    "react/no-array-index-key": "off"
   },
   "overrides": [
     {

--- a/src/components/common/ExpandableList.tsx
+++ b/src/components/common/ExpandableList.tsx
@@ -1,11 +1,33 @@
 import React from 'react';
 import styled from 'styled-components';
 
+/**
+ * Props for the ExpandableList component.
+ * @template T - The type of the items in the list.
+ */
 interface ExpandedListProps<T> {
+  /**
+   * An array of items to display in the list.
+   * @template T - The type of the items in the list.
+   * @type {T[]}
+   */
   items: T[];
+
+  /**
+   * A function to render each item in the list.
+   * @template T - The type of the items in the list.
+   * @param {T} item - The current item in the list.
+   * @returns {React.ReactNode} The rendered JSX for the item.
+   */
   renderItem: (item: T) => React.ReactNode;
 }
 
+/**
+ * A component for rendering a vertically expandable list of items.
+ * Adds a `border-top` style to all items except the first.
+ * @template T - The type of the items in the list.
+ * @param {ExpandedListProps<T>} props - The props for the component.
+ */
 const ExpandableList = <T,>({ items, renderItem }: ExpandedListProps<T>) => {
   return (
     <ListContainer>

--- a/src/components/common/ExpandableList.tsx
+++ b/src/components/common/ExpandableList.tsx
@@ -9,8 +9,8 @@ interface ExpandedListProps<T> {
 const ExpandableList = <T,>({ items, renderItem }: ExpandedListProps<T>) => {
   return (
     <ListContainer>
-      {items.map((item) => (
-        <ListItem>{renderItem(item)}</ListItem>
+      {items.map((item, index) => (
+        <ListItem key={index}>{renderItem(item)}</ListItem>
       ))}
     </ListContainer>
   );

--- a/src/components/common/ExpandableList.tsx
+++ b/src/components/common/ExpandableList.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface ExpandedListProps<T> {
+  items: T[];
+  renderItem: (item: T) => React.ReactNode;
+}
+
+const ExpandableList = <T,>({ items, renderItem }: ExpandedListProps<T>) => {
+  return (
+    <ListContainer>
+      {items.map((item) => (
+        <ListItem>{renderItem(item)}</ListItem>
+      ))}
+    </ListContainer>
+  );
+};
+
+export default ExpandableList;
+
+// Styled Components
+const ListContainer = styled.ul`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 0 ${({ theme }) => theme.padding[16]};
+  border-radius: ${({ theme }) => theme.rounded[24]};
+  background-color: ${({ theme }) => theme.colors.neutral0};
+`;
+
+const ListItem = styled.li`
+  padding: ${({ theme }) => theme.padding[16]} 0;
+  &:not(:first-child) {
+    border-top: 0.1rem solid ${({ theme }) => theme.colors.neutral50};
+  }
+`;


### PR DESCRIPTION
## 🔎 What is this PR?

Resolves #235

## ✨ 설명

- 새롭게 추가된 공통컴포넌트인 ExpandableList를 작업했습니다.
- 단순한 스타일 컴포넌트입니다.
- Props의 `items`에 배열을, `renderItem`에 각 item의 레이아웃 디자인 컴포넌트를 넣어주시면 됩니다.
- 배열이 2개 이상일 경우, Item에 border-top을 적용하여 간단히 만들었습니다.
- JSDoc 주석으로 컴포넌트에 대한 설명을 작성했습니다.

## 📷 스크린샷 (선택)
<img width="286" alt="스크린샷 2025-01-12 오후 8 26 37" src="https://github.com/user-attachments/assets/813e08c7-ad26-4fad-ba01-6c2eba3db9bf" />

black border 내부의 영역에 renderItem UI 컴포넌트가 나타납니다. padding 참고하시고 혹시 수정 필요하면 말씀해주세요.
_(black border는 패딩 표시 위해 임의로 삽입하였고, 실제 컴포넌트에는 포함하지 않았습니당)_


## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청

- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
