### PR TITLE
Section 컴포넌트 background-color

### DIFF
--- a/src/components/common/Section.tsx
+++ b/src/components/common/Section.tsx
@@ -13,7 +13,7 @@ const Container = styled.section`
   border-radius: ${({ theme }) => theme.rounded[16]};
   background-color: ${({ theme }) => theme.colors.neutral0};
 
-  &:not(:has(input:enabled)) {
+  &:not(:has(input:enabled, textarea:enabled, select:enabled)) {
     background-color: ${({ theme }) => theme.colors.neutral200};
   }
 `;

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -6,6 +6,7 @@
   text-decoration: none;
   outline: none;
   box-sizing: border-box;
+  background-color: transparent;
 }
 article,
 aside,


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ 설명

- 버그 해결: Section 컴포넌트를 textarea 태그, select 태그와 함께 사용할 때 enabled임에도 불구하고 disabled일 때의 background-color가 렌더되는 버그가 있었습니다. input 태그만 고려하고 다른 태그를 고려하지 않아서 생긴 이슈였고, 다른 태그를 사용하는 경우의 수를 포함하여 해결했습니다. 최종적으로 Section 컴포넌트는 enabled인 input 자식 요소 또는 enabled인 textarea 자식 요소 또는 enabled인 select 자식 요소를 가지지 않을 때, 즉 자식 요소가 모두 disabled일 때 background-color를 회색으로 렌더합니다.
- 모든 요소의 기본 background-color를 `transparent`로 지정했습니다.

## 📷 스크린샷 (선택)

<img width="300px" src="https://github.com/user-attachments/assets/8e7e96db-64fe-42f6-a779-94fea475acea" />

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
