### PR TITLE
InputText 컴포넌트 글자수표시 수정

### DIFF
--- a/src/components/common/InputText.tsx
+++ b/src/components/common/InputText.tsx
@@ -70,8 +70,6 @@ const Input = styled.input<{ as: string }>`
     color: ${({ theme }) => theme.colors.neutral400};
   }
   &:disabled {
-    background-color: ${({ theme }) => theme.colors.neutral200};
-
     color: ${({ theme }) => theme.colors.neutral400};
   }
 `;

--- a/src/components/common/InputText.tsx
+++ b/src/components/common/InputText.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { NoSelect } from '@src/styles/mixins';
 
 interface Props {
@@ -27,29 +27,37 @@ const InputText = ({
   setValue,
 }: Props) => {
   return (
-    <Input
-      as={as}
-      type='text'
-      name={name}
-      placeholder={placeholder}
-      maxLength={maxLength}
-      required={required}
-      disabled={disabled}
-      value={value}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-        setValue(e.target.value)
-      }
-    />
+    <Container>
+      <Input
+        as={as}
+        type='text'
+        name={name}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        required={required}
+        disabled={disabled}
+        value={value}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setValue(e.target.value)
+        }
+      />
+      {maxLength >= 0 && (
+        <Limit>
+          {value.length}/{maxLength}
+        </Limit>
+      )}
+    </Container>
   );
 };
 
 export default InputText;
 
-const Input = styled.input<{ as: string; value: string; maxLength: number }>`
+const Container = styled.div`
   display: flex;
   flex-flow: column nowrap;
   gap: ${({ theme }) => theme.gap[4]};
-
+`;
+const Input = styled.input<{ as: string }>`
   width: 100%;
   height: ${({ as }) => (as === 'input' ? '1.25rem' : '8.75rem')};
 
@@ -61,23 +69,17 @@ const Input = styled.input<{ as: string; value: string; maxLength: number }>`
   &::placeholder {
     color: ${({ theme }) => theme.colors.neutral400};
   }
-  ${({ value, maxLength }) =>
-    maxLength >= 0 &&
-    css`
-      &::after {
-        content: '${value ? value.length : 0} / ${maxLength}';
-
-        align-self: flex-end;
-
-        ${({ theme }) => theme.fonts.body};
-        color: ${({ theme }) => theme.colors.neutral400};
-
-        ${NoSelect}
-      }
-    `}
   &:disabled {
     background-color: ${({ theme }) => theme.colors.neutral200};
 
     color: ${({ theme }) => theme.colors.neutral400};
   }
+`;
+const Limit = styled.span`
+  align-self: flex-end;
+
+  ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.neutral400};
+
+  ${NoSelect}
 `;

--- a/src/components/common/InputText.tsx
+++ b/src/components/common/InputText.tsx
@@ -6,9 +6,9 @@ interface Props {
   name: string;
   placeholder: string;
   maxLength: number;
-  required: boolean;
+  required?: boolean;
   disabled?: boolean;
-  value?: string;
+  value: string;
   setValue: React.Dispatch<React.SetStateAction<string>>;
 }
 


### PR DESCRIPTION
## 🔎 What is this PR?

> pr에서 발견을 못 했는데 ::after요소로 글자수 표기하는 게 작동하지 않는 거 같슴니다,, 찾아봤을 때 input 태그에서는 작동하지 않는다고 하는데 혹시 코드 작성하실 때 잘 돌아갔나욤??
@rwaeng

## ✨ 설명

- 버그 해결: input 태그는 자식 요소를 갖지 않기 때문에, 가상 요소(자식 요소처럼 작동) 또한 갖지 않습니다. 즉, input 태그는 가상 요소를 사용할 수 없습니다. 글자수표시 요소를 가상 요소에서 비가상 요소로 수정하여 해당 이슈를 해결했습니다.
- InputText 컴포넌트 일부 props의 옵셔널 여부를 수정했습니다.

## 📷 스크린샷 (선택)

<img width="300px" src="https://github.com/user-attachments/assets/15ccb917-fc16-4d1b-856d-5cda8a134de5" />

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
