### PR TITLE
useModal async 작동 개선

### DIFF
--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -2,35 +2,7 @@ import type { RecoilState } from 'recoil';
 import type { Modal } from '@src/types/modal';
 import { useSetRecoilState } from 'recoil';
 
-const useModal = async (
-  type: 'dialog' | 'bottomsheet' | 'serverbar' | 'sidebar',
-) => {
-  let modalState: RecoilState<Modal>;
-
-  switch (type) {
-    case 'bottomsheet': {
-      const { bottomsheetState } = await import('@src/states/atoms');
-      modalState = bottomsheetState;
-      break;
-    }
-    case 'serverbar': {
-      const { serverbarState } = await import('@src/states/atoms');
-      modalState = serverbarState;
-      break;
-    }
-    case 'sidebar': {
-      const { sidebarState } = await import('@src/states/atoms');
-      modalState = sidebarState;
-      break;
-    }
-    case 'dialog':
-    default: {
-      const { dialogState } = await import('@src/states/atoms');
-      modalState = dialogState;
-      break;
-    }
-  }
-
+const useModal = (modalState: RecoilState<Modal>) => {
   const setModal = useSetRecoilState(modalState);
   const transitionMs = 300;
 


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ 설명

- useModal 훅에서 `async`를 제거했습니다.
- useModal 훅의 props `type`을 삭제하고, `modalState`를 추가했습니다. 기존에는 `type`으로 어떤 모달을 제어할지 지정하면 비동기 import로 해당 모달의 recoilState를 불러왔지만, 이제는 useModal 훅을 사용하는 컴포넌트에서 recoilState를 불러온 후, props로 넘겨주면 됩니다.

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
