### PR TITLE
`useModal` 훅 수정사항 반영

### DIFF
--- a/src/components/channel/Carousel.tsx
+++ b/src/components/channel/Carousel.tsx
@@ -1,12 +1,12 @@
-import styled from 'styled-components';
-import { useEffect, useRef, useState } from 'react';
 import type { ClimbingInfo } from '@src/types/climbing';
-import useModal from '@src/hooks/useModal';
+import { useEffect, useRef, useState } from 'react';
 import useEncodedNavigation from '@src/hooks/useEncodedNavigate';
+import useModal from '@src/hooks/useModal';
 import { bottomsheetState } from '@src/states/atoms';
+import styled from 'styled-components';
+import RecruitClimbingBottomSheet from '@src/components/climbing/RecruitClimbingBottomSheet';
 import { ReactComponent as Next } from '@src/assets/images/channel/carousel_btn.svg';
 import { ReactComponent as More } from '@src/assets/images/channel/carousel_more_btn.svg';
-import RecruitClimbingBottomSheet from '@src/components/climbing/RecruitClimbingBottomSheet';
 
 const Carousel = ({
   type,

--- a/src/components/channel/Carousel.tsx
+++ b/src/components/channel/Carousel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { ClimbingInfo } from '@src/types/climbing';
 import useModal from '@src/hooks/useModal';
 import useEncodedNavigation from '@src/hooks/useEncodedNavigate';
+import { bottomsheetState } from '@src/states/atoms';
 import { ReactComponent as Next } from '@src/assets/images/channel/carousel_btn.svg';
 import { ReactComponent as More } from '@src/assets/images/channel/carousel_more_btn.svg';
 import RecruitClimbingBottomSheet from '@src/components/climbing/RecruitClimbingBottomSheet';
@@ -19,8 +20,7 @@ const Carousel = ({
   const [width, setWidth] = useState<number>(0);
   const [startX, setStartX] = useState<number>(0);
   const [startY, setStartY] = useState<number>(0);
-  const { openModal: openBottomsheet, closeModal: closeBottomsheet } =
-    useModal('bottomsheet');
+  const { openModal: openBottomsheet, closeModal: closeBottomsheet } = useModal(bottomsheetState);
 
   useEffect(() => {
     const updateWidth = () => {

--- a/src/components/channel/ChannelChatItem.tsx
+++ b/src/components/channel/ChannelChatItem.tsx
@@ -1,14 +1,14 @@
-import styled from 'styled-components';
-import useLongPress from '@src/hooks/useLongPress';
-import { useGetProfile } from '@src/hooks/query/member';
-import ChatMenu from '@src/components/common/EmojiBottomsheet';
-import Profile from '@src/assets/images/userSettings/background_default.svg';
 import type { DM } from '@src/types/messageRoom';
 import type { ChannelMessage } from '@src/types/channel';
 import { SyntheticEvent, useMemo } from 'react';
-import { formatChatItemTime } from '@src/utils/formatters';
+import useLongPress from '@src/hooks/useLongPress';
 import useModal from '@src/hooks/useModal';
+import { useGetProfile } from '@src/hooks/query/member';
 import { bottomsheetState } from '@src/states/atoms';
+import { formatChatItemTime } from '@src/utils/formatters';
+import styled from 'styled-components';
+import ChatMenu from '@src/components/common/EmojiBottomsheet';
+import Profile from '@src/assets/images/userSettings/background_default.svg';
 
 interface ChatItemProps {
   chatItem: DM | ChannelMessage;

--- a/src/components/channel/ChannelChatItem.tsx
+++ b/src/components/channel/ChannelChatItem.tsx
@@ -8,6 +8,7 @@ import type { ChannelMessage } from '@src/types/channel';
 import { SyntheticEvent, useMemo } from 'react';
 import { formatChatItemTime } from '@src/utils/formatters';
 import useModal from '@src/hooks/useModal';
+import { bottomsheetState } from '@src/states/atoms';
 
 interface ChatItemProps {
   chatItem: DM | ChannelMessage;
@@ -17,7 +18,7 @@ interface ChatItemProps {
 
 const ChannelChatItem = ({ chatItem, memberId, createdAt }: ChatItemProps) => {
   // long press bottomsheet
-  const { openModal: openBottomsheet } = useModal('bottomsheet');
+  const { openModal: openBottomsheet } = useModal(bottomsheetState);
   const longPressHandler = useLongPress({
     onLongPress: () => openBottomsheet(<ChatMenu content={chatItem.content} />),
   });

--- a/src/components/chatting/ChatItem.tsx
+++ b/src/components/chatting/ChatItem.tsx
@@ -4,6 +4,7 @@ import useModal from '@src/hooks/useModal';
 import useLongPress from '@src/hooks/useLongPress';
 import type { DM } from '@src/types/messageRoom';
 import type { ChannelMessage } from '@src/types/channel';
+import { bottomsheetState } from '@src/states/atoms';
 import { formatChatItemTime } from '@src/utils/formatters';
 import ChatMenu from '@src/components/common/EmojiBottomsheet';
 import Profile from '@src/assets/images/userSettings/background_default.svg';
@@ -16,7 +17,7 @@ interface ChatItemProps {
 }
 
 const ChatItem = ({ chatItem, imgUrl, nickname, createdAt }: ChatItemProps) => {
-  const { openModal: openBottomsheet } = useModal('bottomsheet');
+  const { openModal: openBottomsheet } = useModal(bottomsheetState);
   const longPressHandler = useLongPress({
     onLongPress: () => openBottomsheet(<ChatMenu content={chatItem.content} />),
   });

--- a/src/components/chatting/ChatItem.tsx
+++ b/src/components/chatting/ChatItem.tsx
@@ -1,11 +1,11 @@
-import styled from 'styled-components';
-import { SyntheticEvent, useMemo } from 'react';
-import useModal from '@src/hooks/useModal';
-import useLongPress from '@src/hooks/useLongPress';
 import type { DM } from '@src/types/messageRoom';
 import type { ChannelMessage } from '@src/types/channel';
+import { SyntheticEvent, useMemo } from 'react';
+import useLongPress from '@src/hooks/useLongPress';
+import useModal from '@src/hooks/useModal';
 import { bottomsheetState } from '@src/states/atoms';
 import { formatChatItemTime } from '@src/utils/formatters';
+import styled from 'styled-components';
 import ChatMenu from '@src/components/common/EmojiBottomsheet';
 import Profile from '@src/assets/images/userSettings/background_default.svg';
 

--- a/src/components/climbing/Memo.tsx
+++ b/src/components/climbing/Memo.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import useModal from '@src/hooks/useModal';
 import useLoaderData from '@src/hooks/useRoaderData';
+import { dialogState } from '@src/states/atoms';
 import MemoDialog from '@src/components/climbing/MemoDialog';
 import { ReactComponent as Plus } from '@src/assets/icons/hi_outline_plus.svg';
 
@@ -11,7 +12,7 @@ type MemoProps = {
 
 const Memo = ({ memo, isUser }: MemoProps) => {
   const { id } = useLoaderData<{ id: number }>();
-  const { openModal: openDialog, closeModal: closeDialog } = useModal('dialog');
+  const { openModal: openDialog, closeModal: closeDialog } = useModal(dialogState);
 
   const handleClickMemo = () => {
     openDialog(

--- a/src/components/climbing/Memo.tsx
+++ b/src/components/climbing/Memo.tsx
@@ -1,7 +1,7 @@
-import styled from 'styled-components';
 import useModal from '@src/hooks/useModal';
 import useLoaderData from '@src/hooks/useRoaderData';
 import { dialogState } from '@src/states/atoms';
+import styled from 'styled-components';
 import MemoDialog from '@src/components/climbing/MemoDialog';
 import { ReactComponent as Plus } from '@src/assets/icons/hi_outline_plus.svg';
 

--- a/src/components/common/Bottomsheet.tsx
+++ b/src/components/common/Bottomsheet.tsx
@@ -18,13 +18,13 @@ openBottomsheet(ConfirmBottomsheet);
 import type Modal from '@src/types/modal';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
+import useModal from '@src/hooks/useModal';
 import { bottomsheetState } from '@src/states/atoms';
-import useBottomsheet from '@src/hooks/useBottomsheet';
 import Scrim from '@src/components/common/Scrim';
 
 const Bottomsheet = () => {
   const { isOpen, transition, content } = useRecoilValue(bottomsheetState);
-  const { closeBottomsheet } = useBottomsheet();
+  const { closeModal: closeBottomsheet } = useModal(bottomsheetState);
 
   return (
     <Scrim

--- a/src/components/common/Bottomsheet.tsx
+++ b/src/components/common/Bottomsheet.tsx
@@ -16,10 +16,10 @@ openBottomsheet(ConfirmBottomsheet);
 */
 
 import type Modal from '@src/types/modal';
-import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import useModal from '@src/hooks/useModal';
 import { bottomsheetState } from '@src/states/atoms';
+import styled from 'styled-components';
 import Scrim from '@src/components/common/Scrim';
 
 const Bottomsheet = () => {

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -16,10 +16,10 @@ openDialog(ConfirmDialog);
 */
 
 import type Modal from '@src/types/modal';
-import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import useModal from '@src/hooks/useModal';
 import { dialogState } from '@src/states/atoms';
+import styled from 'styled-components';
 import Scrim from '@src/components/common/Scrim';
 
 const Dialog = () => {

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -18,13 +18,13 @@ openDialog(ConfirmDialog);
 import type Modal from '@src/types/modal';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
+import useModal from '@src/hooks/useModal';
 import { dialogState } from '@src/states/atoms';
-import useDialog from '@src/hooks/useDialog';
 import Scrim from '@src/components/common/Scrim';
 
 const Dialog = () => {
   const { isOpen, transition, content } = useRecoilValue(dialogState);
-  const { closeDialog } = useDialog();
+  const { closeModal: closeDialog } = useModal(dialogState);
 
   return (
     <Scrim isOpen={isOpen} transition={transition} closeModal={closeDialog}>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import useModal from '@src/hooks/useModal';
+import { serverbarState, sidebarState } from '@src/states/atoms';
 import Serverbar from '@src/components/common/Serverbar';
 import { ReactComponent as Hamburger } from '@src/assets/icons/fi_menu.svg';
 import { ReactComponent as Back } from '@src/assets/icons/fi_arrow_left.svg';
@@ -21,8 +22,8 @@ const renderButton = (type: string, onClick: () => void, Icon: React.FC) => (
 const Header = ({ text, headerType, onClick }: HeaderProps) => {
   const navigate = useNavigate();
   const handleClick = () => navigate(-1);
-  const { openModal: openServerbar } = useModal('serverbar');
-  const { openModal: openSideBar } = useModal('sidebar');
+  const { openModal: openServerbar } = useModal(serverbarState);
+  const { openModal: openSideBar } = useModal(sidebarState);
 
   return (
     <Layout>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,7 +1,7 @@
-import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import useModal from '@src/hooks/useModal';
 import { serverbarState, sidebarState } from '@src/states/atoms';
+import styled from 'styled-components';
 import Serverbar from '@src/components/common/Serverbar';
 import { ReactComponent as Hamburger } from '@src/assets/icons/fi_menu.svg';
 import { ReactComponent as Back } from '@src/assets/icons/fi_arrow_left.svg';

--- a/src/components/common/Serverbar.tsx
+++ b/src/components/common/Serverbar.tsx
@@ -5,7 +5,7 @@ import { serverbarState, currentServerIdState } from '@src/states/atoms';
 import { ROUTE_PATH } from '@src/constants/routePath';
 import { decodeIdParam } from '@src/utils/formatters';
 import useEncodedNavigate from '@src/hooks/useEncodedNavigate';
-import useServerbar from '@src/hooks/useServerbar';
+import useModal from '@src/hooks/useModal';
 import { useGetServerList } from '@src/hooks/query/server';
 import styled from 'styled-components';
 import Scrim from '@src/components/common/Scrim';
@@ -38,7 +38,7 @@ type buttonConfig = {
  * openServerbar();
  */
 const Serverbar = () => {
-  const { closeServerbar } = useServerbar();
+  const { closeModal: closeServerbar } = useModal(serverbarState);
   const navigate = useNavigate();
   const encodedNavigate = useEncodedNavigate();
   const { serverId: params } = useParams<{ serverId: string }>();

--- a/src/components/common/Serverbar.tsx
+++ b/src/components/common/Serverbar.tsx
@@ -1,12 +1,12 @@
 import type Modal from '@src/types/modal';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { serverbarState, currentServerIdState } from '@src/states/atoms';
 import { ROUTE_PATH } from '@src/constants/routePath';
-import { decodeIdParam } from '@src/utils/formatters';
 import useEncodedNavigate from '@src/hooks/useEncodedNavigate';
 import useModal from '@src/hooks/useModal';
 import { useGetServerList } from '@src/hooks/query/server';
+import { serverbarState, currentServerIdState } from '@src/states/atoms';
+import { decodeIdParam } from '@src/utils/formatters';
 import styled from 'styled-components';
 import Scrim from '@src/components/common/Scrim';
 import { ReactComponent as IcnLibrary } from '@src/assets/icons/md_outline_auto_stories.svg';

--- a/src/components/common/Serverbar.tsx
+++ b/src/components/common/Serverbar.tsx
@@ -38,25 +38,12 @@ type buttonConfig = {
  * openServerbar();
  */
 const Serverbar = () => {
-  const { closeModal: closeServerbar } = useModal(serverbarState);
-  const navigate = useNavigate();
-  const encodedNavigate = useEncodedNavigate();
-  const { serverId: params } = useParams<{ serverId: string }>();
   const location = useLocation();
-
+  const { serverId: params } = useParams<{ serverId: string }>();
   const { isOpen, transition } = useRecoilValue(serverbarState);
-  const setCurrentServerId = useSetRecoilState(currentServerIdState);
-
-  let decodedServerId: number = -1;
-  if (location.pathname.includes('/server')) {
-    decodedServerId = decodeIdParam(params);
-  }
-  setCurrentServerId(decodedServerId);
-
   const { data: serverList } = useGetServerList();
   const isNotiRead = true; // 나중에 수정
   const isChatRead = true; // 나중에 수정
-
   const buttonConfigs: buttonConfig[] = [
     {
       name: '서재',
@@ -90,6 +77,10 @@ const Serverbar = () => {
     },
   ];
 
+  const navigate = useNavigate();
+  const encodedNavigate = useEncodedNavigate();
+  const setCurrentServerId = useSetRecoilState(currentServerIdState);
+  const { closeModal: closeServerbar } = useModal(serverbarState);
   const handleMyClick = (link: string) => {
     navigate(link);
     closeServerbar();
@@ -98,6 +89,12 @@ const Serverbar = () => {
     encodedNavigate('/server', id);
     closeServerbar();
   };
+
+  let decodedServerId: number = -1;
+  if (location.pathname.includes('/server')) {
+    decodedServerId = decodeIdParam(params);
+  }
+  setCurrentServerId(decodedServerId);
 
   return (
     <Scrim isOpen={isOpen} transition={transition} closeModal={closeServerbar}>

--- a/src/components/communitysidebar/CommunitySideBar.tsx
+++ b/src/components/communitysidebar/CommunitySideBar.tsx
@@ -1,16 +1,16 @@
 import type Modal from '@src/types/modal';
-import styled from 'styled-components';
-import Scrim from '@src/components/common/Scrim';
-import CommunityButton from '@src/components/common/IconButton';
-import { ReactComponent as BiCrown } from '@src/assets/icons/bi_crown.svg';
-import useCopyToClipboard from '@src/hooks/useCopyToClipboard';
-import ProfileModal from '@src/components/communitysidebar/ProfileModal';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ROUTE_PATH } from '@src/constants/routePath';
+import useCopyToClipboard from '@src/hooks/useCopyToClipboard';
+import useModal from '@src/hooks/useModal';
 import { sidebarState, dialogState } from '@src/states/atoms';
 import { decodeIdParam, encodeId } from '@src/utils/formatters';
+import styled from 'styled-components';
 import Fieldset from '@src/components/common/Fieldset';
-import useModal from '@src/hooks/useModal';
+import Scrim from '@src/components/common/Scrim';
+import CommunityButton from '@src/components/common/IconButton';
+import ProfileModal from '@src/components/communitysidebar/ProfileModal';
+import { ReactComponent as BiCrown } from '@src/assets/icons/bi_crown.svg';
 
 const CommunitySideBar = () => {
   const { closeModal: closeSideBar } = useModal(sidebarState);

--- a/src/components/communitysidebar/CommunitySideBar.tsx
+++ b/src/components/communitysidebar/CommunitySideBar.tsx
@@ -7,13 +7,14 @@ import useCopyToClipboard from '@src/hooks/useCopyToClipboard';
 import ProfileModal from '@src/components/communitysidebar/ProfileModal';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ROUTE_PATH } from '@src/constants/routePath';
+import { sidebarState, dialogState } from '@src/states/atoms';
 import { decodeIdParam, encodeId } from '@src/utils/formatters';
 import Fieldset from '@src/components/common/Fieldset';
 import useModal from '@src/hooks/useModal';
 
 const CommunitySideBar = () => {
-  const { openModal: sideBar, closeModal: closeSideBar } = useModal('sidebar');
-  const { openModal: openDialog } = useModal('dialog');
+  const { closeModal: closeSideBar } = useModal(sidebarState);
+  const { openModal: openDialog } = useModal(dialogState);
   const { serverId: id } = useParams<{ serverId: string }>();
   const serverId = decodeIdParam(id ?? '-1');
   const { serverInfo, memberList, copyText } = {

--- a/src/components/communitysidebar/CommunitySideBar.tsx
+++ b/src/components/communitysidebar/CommunitySideBar.tsx
@@ -1,5 +1,6 @@
 import type Modal from '@src/types/modal';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import { ROUTE_PATH } from '@src/constants/routePath';
 import useCopyToClipboard from '@src/hooks/useCopyToClipboard';
 import useModal from '@src/hooks/useModal';
@@ -13,6 +14,7 @@ import ProfileModal from '@src/components/communitysidebar/ProfileModal';
 import { ReactComponent as BiCrown } from '@src/assets/icons/bi_crown.svg';
 
 const CommunitySideBar = () => {
+  const { isOpen, transition } = useRecoilValue(sidebarState);
   const { closeModal: closeSideBar } = useModal(sidebarState);
   const { openModal: openDialog } = useModal(dialogState);
   const { serverId: id } = useParams<{ serverId: string }>();
@@ -53,13 +55,13 @@ const CommunitySideBar = () => {
 
   return (
     <Scrim
-      isOpen={sideBar.isOpen}
-      transition={sideBar.transition}
+      isOpen={isOpen}
+      transition={transition}
       closeModal={closeSideBar}
     >
       <SideBarContainer
-        isOpen={sideBar.isOpen}
-        transition={sideBar.transition}
+        isOpen={isOpen}
+        transition={transition}
         onClick={(e) => e.stopPropagation()}
       >
         <CommunityTitleContainer>

--- a/src/components/communitysidebar/ProfileModal.tsx
+++ b/src/components/communitysidebar/ProfileModal.tsx
@@ -1,12 +1,12 @@
-import UserProfile from '@src/components/common/UserProfile';
-import { sidebarState, dialogState } from '@src/states/atoms';
-import styled from 'styled-components';
-import SubButton from '@src/components/common/SubButton';
-import { ReactComponent as Chatting } from '@src/assets/icons/md_outline_chat_bubble.svg';
-import { ReactComponent as Hiking } from '@src/assets/icons/md_outline_auto_stories.svg';
 import { useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@src/constants/routePath';
 import useModal from '@src/hooks/useModal';
+import { sidebarState, dialogState } from '@src/states/atoms';
+import styled from 'styled-components';
+import UserProfile from '@src/components/common/UserProfile';
+import SubButton from '@src/components/common/SubButton';
+import { ReactComponent as Chatting } from '@src/assets/icons/md_outline_chat_bubble.svg';
+import { ReactComponent as Hiking } from '@src/assets/icons/md_outline_auto_stories.svg';
 
 const buttons = {
   hiking: {

--- a/src/components/communitysidebar/ProfileModal.tsx
+++ b/src/components/communitysidebar/ProfileModal.tsx
@@ -1,4 +1,5 @@
 import UserProfile from '@src/components/common/UserProfile';
+import { sidebarState, dialogState } from '@src/states/atoms';
 import styled from 'styled-components';
 import SubButton from '@src/components/common/SubButton';
 import { ReactComponent as Chatting } from '@src/assets/icons/md_outline_chat_bubble.svg';
@@ -39,8 +40,8 @@ const buttons = {
 
 const ProfileModal = ({ memberId }: { memberId: number }) => {
   const navigate = useNavigate();
-  const { closeModal: closeDialog } = useModal('dialog');
-  const { closeModal: closeSideBar } = useModal('sidebar');
+  const { closeModal: closeDialog } = useModal(dialogState);
+  const { closeModal: closeSideBar } = useModal(sidebarState);
 
   const handleClickHiking = () => {
     navigate(`${ROUTE_PATH.library}/${memberId}`);

--- a/src/pages/channel/ChannelAddPage.tsx
+++ b/src/pages/channel/ChannelAddPage.tsx
@@ -3,10 +3,11 @@ import { useState } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
 import { formatDate, decodeIdParam } from '@src/utils/formatters';
 import useEncodedNavigate from '@src/hooks/useEncodedNavigate';
-import useBottomsheet from '@src/hooks/useBottomsheet';
+import useModal from '@src/hooks/useModal';
 import { useCategory } from '@src/hooks/query/category';
 import { usePostChannel } from '@src/hooks/query/channel';
 import { usePostClimbing } from '@src/hooks/query/climbing';
+import { bottomsheetState } from '@src/states/atoms';
 import styled from 'styled-components';
 import Header from '@src/components/common/Header';
 import Fieldset from '@src/components/common/Fieldset';
@@ -24,7 +25,7 @@ import { ReactComponent as IcnRun } from '@src/assets/icons/bi_run.svg';
 
 const ChannelAddPage = () => {
   const navigate = useEncodedNavigate();
-  const { openBottomsheet, closeBottomsheet } = useBottomsheet();
+  const { openModal: openBottomsheet, closeModal: closeBottomsheet } = useModal(bottomsheetState);
   const { serverId } = useParams<{ serverId: string }>();
   const decodedServerId = decodeIdParam(serverId);
   const location = useLocation();

--- a/src/pages/channel/ChannelAddPage.tsx
+++ b/src/pages/channel/ChannelAddPage.tsx
@@ -1,23 +1,21 @@
 import type Book from '@src/types/book';
 import { useState } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
-import { formatDate, decodeIdParam } from '@src/utils/formatters';
 import useEncodedNavigate from '@src/hooks/useEncodedNavigate';
 import useModal from '@src/hooks/useModal';
 import { useCategory } from '@src/hooks/query/category';
 import { usePostChannel } from '@src/hooks/query/channel';
 import { usePostClimbing } from '@src/hooks/query/climbing';
 import { bottomsheetState } from '@src/states/atoms';
+import { formatDate, decodeIdParam } from '@src/utils/formatters';
 import styled from 'styled-components';
 import Header from '@src/components/common/Header';
 import Fieldset from '@src/components/common/Fieldset';
+import Button from '@src/components/common/Button';
 import InputRadio from '@src/components/common/InputRadio';
 import InputDropdown from '@src/components/common/InputDropdown';
 import InputText from '@src/components/common/InputText';
-import InputDatepicker, {
-  type Period,
-} from '@src/components/common/InputDatepicker';
-import Button from '@src/components/common/Button';
+import InputDatepicker, { type Period } from '@src/components/common/InputDatepicker';
 import SearchBottomsheet from '@src/components/channel/SearchBottomsheet';
 import { ReactComponent as IcnHash } from '@src/assets/icons/bi_hash.svg';
 import { ReactComponent as IcnVoice } from '@src/assets/icons/hi_outline_volume_up.svg';

--- a/src/pages/channel/ChannelAddPage.tsx
+++ b/src/pages/channel/ChannelAddPage.tsx
@@ -22,13 +22,10 @@ import { ReactComponent as IcnVoice } from '@src/assets/icons/hi_outline_volume_
 import { ReactComponent as IcnRun } from '@src/assets/icons/bi_run.svg';
 
 const ChannelAddPage = () => {
-  const navigate = useEncodedNavigate();
-  const { openModal: openBottomsheet, closeModal: closeBottomsheet } = useModal(bottomsheetState);
   const { serverId } = useParams<{ serverId: string }>();
   const decodedServerId = decodeIdParam(serverId);
   const location = useLocation();
   const defaultKind = new URLSearchParams(location.search).get('kind') || '';
-
   const { categoryList } = useCategory();
   const { createChannel } = usePostChannel();
   const { createClimbing } = usePostClimbing();
@@ -36,13 +33,12 @@ const ChannelAddPage = () => {
   const [kind, setKind] = useState<string>(defaultKind);
   const [category, setCategory] = useState<string>('');
   const [name, setName] = useState<string>('');
-  const [book, setBook] = useState<Pick<Book, 'title' | 'isbn13'>>({
-    title: '',
-    isbn13: '',
-  });
+  const [book, setBook] = useState<Pick<Book, 'title' | 'isbn13'>>({ title: '', isbn13: '' });
   const [date, setDate] = useState<Period>({ start: '', end: '' });
   const [description, setDescription] = useState<string>('');
 
+  const navigate = useEncodedNavigate();
+  const { openModal: openBottomsheet, closeModal: closeBottomsheet } = useModal(bottomsheetState);
   const calcTomorrow = (): Date => {
     const day = new Date();
     day.setDate(day.getDate() + 1);
@@ -53,7 +49,6 @@ const ChannelAddPage = () => {
     if (kind === 'climb') return !(kind && name && book && date && description);
     return true;
   };
-
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 

--- a/src/pages/channel/ChannelEditPage.tsx
+++ b/src/pages/channel/ChannelEditPage.tsx
@@ -1,27 +1,27 @@
-import styled from 'styled-components';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { useCategory } from '@src/hooks/query/category';
 import useModal from '@src/hooks/useModal';
 import useLoaderData from '@src/hooks/useRoaderData';
 import useToast from '@src/hooks/useToast';
-import { encodeId } from '@src/utils/formatters';
-import Header from '@src/components/common/Header';
-import Button from '@src/components/common/Button';
-import InputText from '@src/components/common/InputText';
-import InputDropdown from '@src/components/common/InputDropdown';
-import ButtonBackground from '@src/components/common/ButtonBackground';
-import DeleteConfirmModal from '@src/components/common/DeleteConfirmModal';
-import UnderlineButton from '@src/components/common/UnderlineButton';
+import { useCategory } from '@src/hooks/query/category';
 import {
   useDeleteChannel,
   useGetServerChannel,
   usePatchChannel,
 } from '@src/hooks/query/channel';
-import Section from '@src/components/common/Section';
 import { dialogState, categoryIdState } from '@src/states/atoms';
+import { encodeId } from '@src/utils/formatters';
+import styled from 'styled-components';
+import Header from '@src/components/common/Header';
 import Fieldset from '@src/components/common/Fieldset';
+import Section from '@src/components/common/Section';
+import DeleteConfirmModal from '@src/components/common/DeleteConfirmModal';
+import Button from '@src/components/common/Button';
+import ButtonBackground from '@src/components/common/ButtonBackground';
+import UnderlineButton from '@src/components/common/UnderlineButton';
+import InputText from '@src/components/common/InputText';
+import InputDropdown from '@src/components/common/InputDropdown';
 
 const findItemByKey = <T, K extends keyof T>(
   items: T[],

--- a/src/pages/channel/ChannelEditPage.tsx
+++ b/src/pages/channel/ChannelEditPage.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { categoryIdState } from '@src/states/atoms';
 import { useCategory } from '@src/hooks/query/category';
 import useModal from '@src/hooks/useModal';
 import useLoaderData from '@src/hooks/useRoaderData';
@@ -21,6 +20,7 @@ import {
   usePatchChannel,
 } from '@src/hooks/query/channel';
 import Section from '@src/components/common/Section';
+import { dialogState, categoryIdState } from '@src/states/atoms';
 import Fieldset from '@src/components/common/Fieldset';
 
 const findItemByKey = <T, K extends keyof T>(
@@ -32,7 +32,7 @@ const findItemByKey = <T, K extends keyof T>(
 };
 
 const ChannelEditPage = () => {
-  const { openModal: openDialog, closeModal: closeDialog } = useModal('dialog');
+  const { openModal: openDialog, closeModal: closeDialog } = useModal(dialogState);
   const addToast = useToast();
 
   const { id: serverId } = useLoaderData<{ id: string }>();

--- a/src/pages/climbing/ClimbingEditPage.tsx
+++ b/src/pages/climbing/ClimbingEditPage.tsx
@@ -9,6 +9,7 @@ import {
   useGetClimbing,
   usePatchClimbing,
 } from '@src/hooks/query/climbing';
+import { dialogState } from '@src/states/atoms';
 import { encodeId, formatDate } from '@src/utils/formatters';
 import Button from '@src/components/common/Button';
 import ButtonBackground from '@src/components/common/ButtonBackground';
@@ -25,7 +26,7 @@ import Fieldset from '@src/components/common/Fieldset';
 const ClimbingEditPage = () => {
   const navigate = useEncodedNavigation();
   const addToast = useToast();
-  const { openModal: openDialog, closeModal: closeDialog } = useModal('dialog');
+  const { openModal: openDialog, closeModal: closeDialog } = useModal(dialogState);
 
   const serverId = sessionStorage.getItem('currentServer');
   const { id: climbingId } = useLoaderData<{ id: string }>();

--- a/src/pages/climbing/ClimbingEditPage.tsx
+++ b/src/pages/climbing/ClimbingEditPage.tsx
@@ -1,9 +1,8 @@
-import styled from 'styled-components';
 import { useEffect, useState } from 'react';
-import useLoaderData from '@src/hooks/useRoaderData';
 import useEncodedNavigation from '@src/hooks/useEncodedNavigate';
-import useToast from '@src/hooks/useToast';
 import useModal from '@src/hooks/useModal';
+import useLoaderData from '@src/hooks/useRoaderData';
+import useToast from '@src/hooks/useToast';
 import {
   useDeleteClimbing,
   useGetClimbing,
@@ -11,17 +10,18 @@ import {
 } from '@src/hooks/query/climbing';
 import { dialogState } from '@src/states/atoms';
 import { encodeId, formatDate } from '@src/utils/formatters';
+import styled from 'styled-components';
+import Header from '@src/components/common/Header';
+import Fieldset from '@src/components/common/Fieldset';
+import Section from '@src/components/common/Section';
+import DeleteConfirmModal from '@src/components/common/DeleteConfirmModal';
 import Button from '@src/components/common/Button';
 import ButtonBackground from '@src/components/common/ButtonBackground';
-import Header from '@src/components/common/Header';
+import UnderlineButton from '@src/components/common/UnderlineButton';
+import InputText from '@src/components/common/InputText';
 import InputDatepicker, {
   Period,
 } from '@src/components/common/InputDatepicker';
-import InputText from '@src/components/common/InputText';
-import DeleteConfirmModal from '@src/components/common/DeleteConfirmModal';
-import UnderlineButton from '@src/components/common/UnderlineButton';
-import Section from '@src/components/common/Section';
-import Fieldset from '@src/components/common/Fieldset';
 
 const ClimbingEditPage = () => {
   const navigate = useEncodedNavigation();

--- a/src/pages/userSettings/SettingsPage.tsx
+++ b/src/pages/userSettings/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@src/constants/routePath';
 import useModal from '@src/hooks/useModal';
 import { useDeleteAccount } from '@src/hooks/query/auth';
+import { dialogState } from '@src/states/atoms';
 import Header from '@src/components/common/Header';
 import IconButton from '@src/components/common/IconButton';
 import UserProfile from '@src/components/common/UserProfile';
@@ -11,7 +12,7 @@ import DeleteConfirmModal from '@src/components/common/DeleteConfirmModal';
 const SettingsPage = () => {
   const navigate = useNavigate();
   const { delAccount } = useDeleteAccount();
-  const { openModal: openDialog, closeModal: closeDialog } = useModal('dialog');
+  const { openModal: openDialog, closeModal: closeDialog } = useModal(dialogState);
 
   const handleDelete = () => {
     delAccount.mutate();

--- a/src/pages/userSettings/SettingsPage.tsx
+++ b/src/pages/userSettings/SettingsPage.tsx
@@ -1,13 +1,13 @@
-import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@src/constants/routePath';
 import useModal from '@src/hooks/useModal';
 import { useDeleteAccount } from '@src/hooks/query/auth';
 import { dialogState } from '@src/states/atoms';
+import styled from 'styled-components';
 import Header from '@src/components/common/Header';
-import IconButton from '@src/components/common/IconButton';
 import UserProfile from '@src/components/common/UserProfile';
 import DeleteConfirmModal from '@src/components/common/DeleteConfirmModal';
+import IconButton from '@src/components/common/IconButton';
 
 const SettingsPage = () => {
   const navigate = useNavigate();

--- a/src/tests/common/Bottomsheet.test.tsx
+++ b/src/tests/common/Bottomsheet.test.tsx
@@ -1,9 +1,10 @@
 import { screen, fireEvent } from '@testing-library/react';
-import useBottomsheet from '@src/hooks/useBottomsheet';
+import useModal from '@src/hooks/useModal';
+import { bottomsheetState } from '@src/states/atoms';
 import Bottomsheet from '@src/components/common/Bottomsheet';
 
 const App = () => {
-  const { openBottomsheet, closeBottomsheet } = useBottomsheet();
+  const { openModal: openBottomsheet, closeModal: closeBottomsheet } = useModal(bottomsheetState);
   const ConfirmBottomsheet: React.ReactNode = (
     <button
       data-testid='bottomsheet-close'

--- a/src/tests/common/Bottomsheet.test.tsx
+++ b/src/tests/common/Bottomsheet.test.tsx
@@ -31,6 +31,8 @@ describe('Bottomsheet', () => {
     const modal = document.createElement('div');
     modal.id = 'modal';
     document.body.appendChild(modal);
+  });
+  test('openBottomsheet()로 열고, closeBottomsheet()로 닫아야 한다.', () => {
     // 웹앱 렌더
     render(
       <>
@@ -41,28 +43,43 @@ describe('Bottomsheet', () => {
     // 바텀시트 열기
     const openBtn = screen.getByTestId('bottomsheet-open');
     fireEvent.click(openBtn);
-  });
-  test('openBottomsheet()로 열고, closeBottomsheet()로 닫아야 한다.', () => {
+    // 테스트
     const bottomsheet = screen.getByLabelText('bottomsheet');
-
     expect(bottomsheet).toBeInTheDocument();
-
     const closeBtn = screen.getByTestId('bottomsheet-close');
     fireEvent.click(closeBtn);
-
     setTimeout(() => expect(bottomsheet).not.toBeInTheDocument(), 300);
   });
   test('openBottomsheet()로 전달한 요소를 렌더해야 한다.', () => {
+    // 웹앱 렌더
+    render(
+      <>
+        <App />
+        <Bottomsheet />
+      </>,
+    );
+    // 바텀시트 열기
+    const openBtn = screen.getByTestId('bottomsheet-open');
+    fireEvent.click(openBtn);
+    // 테스트
     const closeBtn = screen.getByTestId('bottomsheet-close');
-
     expect(closeBtn).toBeInTheDocument();
   });
   test('Scrim을 클릭하면 닫혀야 한다.', () => {
+    // 웹앱 렌더
+    render(
+      <>
+        <App />
+        <Bottomsheet />
+      </>,
+    );
+    // 바텀시트 열기
+    const openBtn = screen.getByTestId('bottomsheet-open');
+    fireEvent.click(openBtn);
+    // 테스트
     const bottomsheet = screen.getByLabelText('bottomsheet');
-
     const scrim = screen.getByLabelText('scrim');
     fireEvent.click(scrim);
-
     setTimeout(() => expect(bottomsheet).not.toBeInTheDocument(), 300);
   });
 });

--- a/src/tests/common/Dialog.test.tsx
+++ b/src/tests/common/Dialog.test.tsx
@@ -1,9 +1,10 @@
 import { screen, fireEvent } from '@testing-library/react';
-import useDialog from '@src/hooks/useDialog';
+import useModal from '@src/hooks/useModal';
+import { dialogState } from '@src/states/atoms';
 import Dialog from '@src/components/common/Dialog';
 
 const App = () => {
-  const { openDialog, closeDialog } = useDialog();
+  const { openModal: openDialog, closeModal: closeDialog } = useModal(dialogState);
   const ConfirmDialog: React.ReactNode = (
     <button
 	  data-testid='dialog-close'

--- a/src/tests/common/Dialog.test.tsx
+++ b/src/tests/common/Dialog.test.tsx
@@ -31,6 +31,8 @@ describe('Dialog', () => {
     const modal = document.createElement('div');
     modal.id = 'modal';
     document.body.appendChild(modal);
+  });
+  test('openDialog()로 열고, closeDialog()로 닫아야 한다.', () => {
     // 웹앱 렌더
     render(
       <>
@@ -41,28 +43,43 @@ describe('Dialog', () => {
     // 다이얼로그 열기
     const openBtn = screen.getByTestId('dialog-open');
     fireEvent.click(openBtn);
-  });
-  test('openDialog()로 열고, closeDialog()로 닫아야 한다.', () => {
+    // 테스트
     const dialog = screen.getByRole('dialog');
-
     expect(dialog).toBeInTheDocument();
-
     const closeBtn = screen.getByTestId('dialog-close');
     fireEvent.click(closeBtn);
-
     setTimeout(() => expect(dialog).not.toBeInTheDocument(), 300);
   });
   test('openDialog()로 전달한 요소를 렌더해야 한다.', () => {
+    // 웹앱 렌더
+    render(
+      <>
+        <App />
+        <Dialog />
+      </>,
+    );
+    // 다이얼로그 열기
+    const openBtn = screen.getByTestId('dialog-open');
+    fireEvent.click(openBtn);
+    // 테스트
     const closeBtn = screen.getByTestId('dialog-close');
-
     expect(closeBtn).toBeInTheDocument();
   });
   test('Scrim을 클릭하면 닫혀야 한다.', () => {
+    // 웹앱 렌더
+    render(
+      <>
+        <App />
+        <Dialog />
+      </>,
+    );
+    // 다이얼로그 열기
+    const openBtn = screen.getByTestId('dialog-open');
+    fireEvent.click(openBtn);
+    // 테스트
     const dialog = screen.getByLabelText('dialog');
-
     const scrim = screen.getByLabelText('scrim');
     fireEvent.click(scrim);
-
     setTimeout(() => expect(dialog).not.toBeInTheDocument(), 300);
   });
 });


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ 설명

- `useModal` 수정사항을 반영했습니다. RecoilState를 import하고 `useModal`의 props로 넘겨주었습니다.
  - 특히 `CommunitySideBar` 컴포넌트에서, 기존에는 `useSidebar` 훅을 통해 `openSidebar`, `closeSidebar`, `sidebarState`를 사용하고 있었는데 개선 과정에서 `useModal` 훅으로 통합하며 더이상 RecoilState의 값을 반환하지 않아, 각 컴포넌트에서 useRecoilValue를 통해 RecoilState의 값을 사용하도록 수정했습니다.
- 코드를 포맷팅했습니다. `useModal` 수정사항을 반영하기 위해 코드를 이해하는 과정에서 이루어진 것이라 일부 파일만 수정했습니다.
  - import문을 정렬했습니다. 타입, 제어, 스타일 순으로 정렬하고, 세부적으로 경로 알파벳순으로 정렬했습니다.
  - 코드를 정렬했습니다. 변수 선언, 함수 선언, 로직 순으로 정렬했습니다.
- 테스트 `Bottomsheet.test.tsx`, `Dialog.test.tsx`의 린트 에러를 해결했습니다.
  - beforeEach에서 render 함수를 사용하지 않도록 수정했습니다.

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청

각 코드 담장자께서는 자신의 코드가 수정된 부분을 확인해 주시기 바랍니다.
