### PR TITLE
Bottomsheet 컴포넌트 HandleBar `border-radius` 수정

### DIFF
--- a/src/components/common/Bottomsheet.tsx
+++ b/src/components/common/Bottomsheet.tsx
@@ -70,6 +70,6 @@ const HandleBar = styled.button`
   width: 1.875rem;
   height: 0.1875rem;
 
-  border-radius: 50%;
+  border-radius: 6.1875rem;
   background-color: ${({ theme }) => theme.colors.blue300};
 `;


### PR DESCRIPTION
## 🔎 What is this PR?

- Figma: 프로토타입 캡처
   <img width="350px" src="https://github.com/user-attachments/assets/16765346-838e-4875-b114-bbc23accbd00" />

## ✨ 설명

Bottomsheet 컴포넌트의 HandleBar `border-radius`를 잘못 지정했던 문제를 해결했습니다.

<table>
  <tr>
    <th width="50%">before</th>
    <th width="50%">after</th>
  </tr>
  <tr>
    <td valign="top"><img src="https://github.com/user-attachments/assets/a013b59f-b6ea-4d4e-a8a2-9563274ae3a9" /></td>
    <td><img src="https://github.com/user-attachments/assets/d2742bcf-9b42-40b5-b508-797c9e04ef66" /></td>
  </tr>
</table>

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
