### PR TITLE
Tag 컴포넌트 `onClick` props 추가

### DIFF
--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -5,12 +5,13 @@ interface Props {
   Icon?: React.FC<React.SVGProps<SVGSVGElement>>;
   text: string | number;
   color: TagColor;
+  onClick?: () => void;
   className?: string;
 }
 
-const Tag = ({ Icon, text, color, className }: Props) => {
+const Tag = ({ Icon, text, color, onClick, className }: Props) => {
   return (
-    <Wrapper className={className} color={color}>
+    <Wrapper className={className} onClick={onClick} color={color}>
       {Icon && <Icon width={12} height={12} />}
       <span>{text}</span>
     </Wrapper>

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const Tag = ({ Icon, text, color, onClick, className }: Props) => {
   return (
-    <Wrapper className={className} onClick={onClick} color={color}>
+    <Wrapper className={className} onClick={onClick} $color={color}>
       {Icon && <Icon width={12} height={12} />}
       <span>{text}</span>
     </Wrapper>
@@ -20,7 +20,7 @@ const Tag = ({ Icon, text, color, onClick, className }: Props) => {
 
 export default Tag;
 
-const Wrapper = styled.mark<{ color: TagColor }>`
+const Wrapper = styled.mark<{ $color: TagColor }>`
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
@@ -34,8 +34,8 @@ const Wrapper = styled.mark<{ color: TagColor }>`
 
   ${({ theme }) => theme.fonts.caption};
 
-  ${({ color, theme }) => {
-    switch (color) {
+  ${({ $color, theme }) => {
+    switch ($color) {
       case 'lime':
         return `
           background-color: ${theme.colors.lime100};

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -2,14 +2,14 @@ import styled from 'styled-components';
 
 type TagColor = 'lime' | 'blue' | 'neutral';
 interface Props {
+  color: TagColor;
   Icon?: React.FC<React.SVGProps<SVGSVGElement>>;
   text: string | number;
-  color: TagColor;
   onClick?: () => void;
   className?: string;
 }
 
-const Tag = ({ Icon, text, color, onClick, className }: Props) => {
+const Tag = ({ color, Icon, text, onClick, className }: Props) => {
   return (
     <Wrapper className={className} onClick={onClick} $color={color}>
       {Icon && <Icon width={12} height={12} />}


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ 설명

- Tag 컴포넌트에 `onClick` props를 옵셔널로 추가했습니다.
- Tag 컴포넌트의 styled-components props 이름을 수정했습니다. `color` → `$color`
- Tag 컴포넌트의 props 순서를 수정했습니다.

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
