### PR TITLE
Identifier 'Toast' has already been declared.

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -9,7 +9,7 @@ const addToast = useToast();
 addToast({ kind: 'error', content: '토스트 내용' });
 */
 
-import type Toast from '@src/types/toast';
+import type ToastType from '@src/types/toast';
 import { createPortal } from 'react-dom';
 import { useRecoilValue } from 'recoil';
 import { toastState } from '@src/states/atoms';
@@ -20,7 +20,7 @@ import { ReactComponent as IcnSuccess } from '@src/assets/icons/toast_success.sv
 import { ReactComponent as IcnError } from '@src/assets/icons/toast_error.svg';
 
 const IconConfig: Record<
-  Toast['kind'],
+  ToastType['kind'],
   React.FC<React.SVGProps<SVGSVGElement>>
 > = {
   info: IcnInfo,


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ 설명

`Identifier 'Toast' has already been declared.` 컴파일 에러를 해결했습니다.
import한 타입의 이름과 컴포넌트의 이름이 같아 생긴 문제였습니다.
타입을 import할 때 이름을 다르게 하여 해결했습니다.

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
