### PR TITLE
책 검색 페이지

### DIFF
--- a/src/pages/library/SearchPage.tsx
+++ b/src/pages/library/SearchPage.tsx
@@ -7,6 +7,7 @@ import {
 import { ROUTE_PATH } from '@src/constants/routePath';
 import { useGetBookList } from '@src/hooks/query/book';
 import styled from 'styled-components';
+import Spinner from '@src/components/common/Spinner';
 import BookListItem from '@src/components/library/BookListItem';
 import { ReactComponent as IcnSearch } from '@src/assets/icons/md_outline_search.svg';
 import { ReactComponent as IcnClose } from '@src/assets/icons/ck_close.svg';
@@ -17,7 +18,7 @@ const SearchPage = () => {
   const keyword: string = new URLSearchParams(location.search).get('keyword') ?? '';
 
   // API 요청
-  const { data } = useGetBookList(keyword);
+  const { data, isLoading, isSuccess } = useGetBookList(keyword);
 
   const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     // 새로고침 방지 (기본 기능 비활성화)
@@ -54,20 +55,26 @@ const SearchPage = () => {
       </Header>
       {keyword && (
         <main>
-          {data.length > 0 ? (
-            <Ul>
-              {data.map((item) => (
-                <Link
-                  key={item.isbn13}
-                  to={`${ROUTE_PATH.libraryBookSearch}/${item.isbn13}`}
-                >
-                  <BookListItem {...item} />
-                </Link>
-              ))}
-            </Ul>
-          ) : (
-            <strong>검색 결과가 없어요.</strong>
+          {isLoading && (
+            <strong>
+              <Spinner />
+            </strong>
           )}
+          {isSuccess &&
+            (data.length > 0 ? (
+              <Ul>
+                {data.map((item) => (
+                  <Link
+                    key={item.isbn13}
+                    to={`${ROUTE_PATH.libraryBookSearch}/${item.isbn13}`}
+                  >
+                    <BookListItem {...item} />
+                  </Link>
+                ))}
+              </Ul>
+            ) : (
+              <strong>검색 결과가 없어요.</strong>
+            ))}
         </main>
       )}
     </>

--- a/src/pages/library/SearchPage.tsx
+++ b/src/pages/library/SearchPage.tsx
@@ -77,6 +77,10 @@ const SearchPage = () => {
 export default SearchPage;
 
 const Header = styled.header`
+  position: fixed;
+  top: 0;
+  left: 0;
+
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -21,6 +21,13 @@ nav,
 section {
   display: block;
 }
+a,
+a:link,
+a:visited,
+a:active {
+  text-decoration: none;
+  color: unset;
+}
 ol,
 ul,
 li {


### PR DESCRIPTION
## 🔎 What is this PR?

## ✨ 설명

- 책 검색 페이지 레이아웃을 반영했습니다. 검색창에`position: fixed;`를 주었습니다.
- 책 검색 페이지 검색결과 로딩 중 Spinner 컴포넌트를 렌더링하도록 했습니다. react-query 훅에서 `isLoading`과 `isSuccess`를 받아 `isLoading`이 `true`일 때 Spinner 컴포넌트를 렌더링하고, `isSuccess`가 `true`일 때 검색결과 목록 또는 검색결과가 없다는 문자열을 렌더링하도록 했습니다.
- `a` 태그 관련 기본 스타일을 reset.css에서 초기화했습니다.

## 📷 스크린샷 (선택)

## ☑️ 테스트 체크리스트

## 💡 집중 리뷰 요청
